### PR TITLE
Actualizar flujos de trabajo y Dockerfiles para implementación de Butakero Bot en arquitectura ARM64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -44,6 +44,8 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/butakero-bot-aws:latest
           platforms: linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Deploy a EC2
         uses: appleboy/ssh-action@master

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -25,7 +24,6 @@ var (
 )
 
 func main() {
-	fmt.Println("test")
 	loggerCfg := zap.NewDevelopmentConfig()
 	loggerCfg.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
 	logger, _ := loggerCfg.Build()

--- a/dockerfile.aws
+++ b/dockerfile.aws
@@ -1,23 +1,25 @@
-FROM --platform=linux/arm64 golang:1.21 AS builder
+FROM --platform=linux/arm64 arm64v8/golang:1.21-alpine3.18 AS builder
 
-RUN apt-get update && apt-get install -y build-essential libopus-dev \
+# Instalar dependencias necesarias
+RUN apk add --no-cache build-base opus-dev opusfile-dev \
     && go install github.com/bwmarrin/dca/cmd/dca@latest
 
 WORKDIR /src/
 COPY go.mod go.sum ./
 RUN go mod download
-COPY . .
+COPY cmd/ cmd/
+COPY internal/ internal/
 RUN CGO_ENABLED=1 GOARCH=arm64 go build -o /bin/butakero cmd/main.go
 
 # Etapa final del contenedor
-FROM --platform=linux/arm64 ubuntu:latest
+FROM --platform=linux/arm64 arm64v8/alpine:edge
 
 ENV DISCORDTOKEN=
 ENV COMMANDPREFIX=
 
-RUN apt-get update && apt-get install -y ffmpeg wget libopusfile-dev \
-    && wget "https://github.com/yt-dlp/yt-dlp/releases/download/2023.10.13/yt-dlp_linux_aarch64" -O /usr/local/bin/yt-dlp \
-    && chmod +x /usr/local/bin/yt-dlp
+# Instalar dependencias necesarias para la ejecución
+RUN apk add --no-cache ffmpeg wget opusfile yt-dlp \
+    && apk add --no-cache gcompat libstdc++
 
 # Copiar los binarios compilados desde la etapa de construcción
 COPY --from=builder /bin/butakero /bin/butakero

--- a/dockerfile.local
+++ b/dockerfile.local
@@ -5,15 +5,13 @@ RUN apt-get update \
   && go install github.com/bwmarrin/dca/cmd/dca@latest
 
 WORKDIR /src/
-
 COPY go.mod go.sum ./
 RUN go mod download
-
-COPY . .
-
+COPY cmd/ cmd/
+COPY internal/ internal/
 RUN CGO_ENABLED=1 GOARCH=amd64 go build -o /bin/butakero cmd/main.go
 
-FROM ubuntu
+FROM ubuntu:22.04
 
 ARG YT_DLP_VERSION="2023.10.13"
 


### PR DESCRIPTION
Este PR actualiza nuestros flujos de trabajo y Dockerfiles para facilitar la implementación de Butakero Bot en arquitectura ARM64. Los cambios incluyen la configuración de caché para la construcción de imágenes Docker, la actualización de las dependencias y la configuración de las credenciales necesarias.

Detalles de los cambios:
- Actualización de los flujos de trabajo "Go Continuous Delivery Pipeline" y "Go Development Pipeline" para escuchar los eventos de finalización en la rama master del repositorio.
- Actualización de los Dockerfiles para construir y empujar imágenes compatibles con la arquitectura ARM64.
- Configuración de caché para acelerar la construcción de imágenes Docker.
- Actualización de las dependencias y configuraciones necesarias para la implementación en EC2.