### PR TITLE
Agregada funcionalidad de métricas Prometheus y servidor HTTP

### DIFF
--- a/internal/metrics/command_usage_counter.go
+++ b/internal/metrics/command_usage_counter.go
@@ -1,0 +1,30 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type CommandUsageCounter struct {
+	counterVec *prometheus.CounterVec
+}
+
+func NewCommandUsageCounter() *CommandUsageCounter {
+	return &CommandUsageCounter{
+		counterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "command_usage_total",
+			Help: "Número total de veces que se utilizan comandos, etiquetados por comando y servidor",
+		},
+			[]string{"command"},
+		),
+	}
+}
+
+func (c *CommandUsageCounter) Describe(ch chan<- *prometheus.Desc) {
+	c.counterVec.Describe(ch)
+}
+
+func (c *CommandUsageCounter) Collect(ch chan<- prometheus.Metric) {
+	c.counterVec.Collect(ch)
+}
+
+func (c *CommandUsageCounter) Inc(labels ...string) {
+	c.counterVec.WithLabelValues(labels...).Inc()
+}

--- a/internal/metrics/custom_metric.go
+++ b/internal/metrics/custom_metric.go
@@ -1,0 +1,10 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// CustomMetric define la interfaz que deben cumplir todas las métricas personalizadas.
+type CustomMetric interface {
+	Describe(chan<- *prometheus.Desc)
+	Collect(chan<- prometheus.Metric)
+	Inc(labels ...string)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,72 @@
+package metrics
+
+import (
+	"flag"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+	"regexp"
+)
+
+type RegistryMetric interface {
+	Register(metric CustomMetric)
+	RegisterStandardMetrics()
+	GetRegistry() *prometheus.Registry
+}
+
+type PrometheusRegistry struct {
+	registry *prometheus.Registry
+}
+
+func NewPrometheusRegistry() *PrometheusRegistry {
+	return &PrometheusRegistry{
+		registry: prometheus.NewRegistry(),
+	}
+}
+
+func (pr *PrometheusRegistry) Register(metric CustomMetric) {
+	pr.registry.MustRegister(metric)
+}
+
+func (pr *PrometheusRegistry) RegisterStandardMetrics() {
+	pr.registry.MustRegister(collectors.NewBuildInfoCollector())
+	pr.registry.MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}),
+	))
+}
+
+func (pr *PrometheusRegistry) GetRegistry() *prometheus.Registry {
+	return pr.registry
+}
+
+type HTTPMetricsServer interface {
+	Start() error
+}
+
+type PrometheusHTTPServer struct {
+	Address  string
+	Registry RegistryMetric
+}
+
+func NewPrometheusHTTPServer(address string, registry RegistryMetric) *PrometheusHTTPServer {
+	return &PrometheusHTTPServer{
+		Address:  address,
+		Registry: registry,
+	}
+}
+
+func (s *PrometheusHTTPServer) Start() error {
+	flag.Parse()
+
+	s.Registry.RegisterStandardMetrics()
+
+	http.Handle("/metrics", promhttp.HandlerFor(
+		s.Registry.GetRegistry(),
+		promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		}))
+	fmt.Println("Iniciando server de Prometheus HTTP metric...", s.Address)
+	return http.ListenAndServe(s.Address, nil)
+}


### PR DESCRIPTION
## Agregada funcionalidad de métricas Prometheus y servidor HTTP

Este pull request introduce la funcionalidad necesaria para recopilar métricas utilizando Prometheus en nuestra aplicación. Se ha agregado una nueva estructura `CommandUsageCounter` para contar el uso de comandos, junto con la configuración del registro de métricas Prometheus y un servidor HTTP para exponer las métricas a través de la ruta `/metrics`. Esto proporciona una forma de monitorear y visualizar el uso de comandos en nuestra aplicación.
