### PR TITLE
Actualizar Docker Compose y agregar paquete de profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /terraform/terraform.tfstate
 /terraform/terraform.tfstate.backup
 /terraform/terraform.tfvars
+.env

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,10 +7,10 @@ import (
 	"github.com/Tomas-vilte/GoMusicBot/internal/logging"
 	"github.com/Tomas-vilte/GoMusicBot/internal/metrics"
 	"github.com/Tomas-vilte/GoMusicBot/internal/music/fetcher"
+	"github.com/Tomas-vilte/GoMusicBot/internal/profiler"
 	"github.com/bwmarrin/discordgo"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -41,6 +41,7 @@ func main() {
 			logger.Error("Error al iniciar el servidor HTTP de métricas Prometheus: ", zap.Error(err))
 		}
 	}()
+	profiler.StartProfiler()
 	defer func() {
 		// Cerrar el logger cuando la función termine.
 		err := logger.Close()

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/grafana/pyroscope-go v1.1.1 // indirect
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.6 // indirect
+	github.com/klauspost/compress v1.17.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,14 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grafana/pyroscope-go v1.1.1 h1:PQoUU9oWtO3ve/fgIiklYuGilvsm8qaGhlY4Vw6MAcQ=
+github.com/grafana/pyroscope-go v1.1.1/go.mod h1:Mw26jU7jsL/KStNSGGuuVYdUq7Qghem5P8aXYXSXG88=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.6/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/klauspost/compress v1.17.3 h1:qkRjuerhUU1EmXLYGkSH6EZL+vPSxIrYjLNAK4slzwA=
+github.com/klauspost/compress v1.17.3/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=

--- a/grafana/datasources/datasource.yml
+++ b/grafana/datasources/datasource.yml
@@ -1,7 +1,14 @@
 apiVersion: 1
+
 datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
+
+  - name: Grafana Pyroscope
+    type: grafana-pyroscope-datasource
+    url: http://pyroscope:4040
+    jsonData:
+      minStep: '15s'

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1,0 +1,25 @@
+package profiler
+
+import (
+	"github.com/grafana/pyroscope-go"
+	"log"
+)
+
+// StartProfiler inicia el profiler de Pyroscope
+func StartProfiler() {
+	_, err := pyroscope.Start(pyroscope.Config{
+		ApplicationName: "GoMusicBot",
+		ServerAddress:   "http://pyroscope:4040",
+		ProfileTypes: []pyroscope.ProfileType{
+			pyroscope.ProfileCPU,
+			pyroscope.ProfileAllocObjects,
+			pyroscope.ProfileAllocSpace,
+			pyroscope.ProfileInuseObjects,
+			pyroscope.ProfileInuseSpace,
+			pyroscope.ProfileGoroutines,
+		},
+	})
+	if err != nil {
+		log.Fatalf("Error al iniciar Pyroscope: %v", err)
+	}
+}

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -11,10 +11,21 @@ services:
       - "8080:8080"
     networks:
       - monitoring-net
-
     restart: always
+  
+  pyroscope:
+    image: grafana/pyroscope:1.6.0
+    container_name: pyroscope
+    ports:
+      - "4040:4040"
+    environment:
+      - PYROSCOPE_SCRAPE_ENDPOINT_ENABLED=true
+    networks:
+      - monitoring-net
+    restart: always
+
   prometheus:
-    image: prom/prometheus:v2.35.0
+    image: prom/prometheus:v2.51.2
     container_name: prometheus
     ports:
       - "9090:9090"
@@ -26,7 +37,7 @@ services:
 
 
   grafana:
-    image: grafana/grafana:8.0.6
+    image: grafana/grafana:11.0.0
     container_name: grafana
     ports:
       - "3000:3000"
@@ -43,7 +54,7 @@ services:
 
 
   node-exporter:
-    image: prom/node-exporter:v1.2.2
+    image: prom/node-exporter:v1.8.1
     container_name: node-exporter
     ports:
       - "9100:9100"

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -13,3 +13,7 @@ scrape_configs:
   - job_name: 'butakero-bot'
     static_configs:
       - targets: ['bot:8080']
+
+  - job_name: 'pyroscope'
+    static_configs:
+      - targets: ['pyroscope:4040']


### PR DESCRIPTION
### Descripción

Este PR incluye las siguientes actualizaciones y adiciones:

1. **Actualizar Docker Compose:**
   - Se actualizaron las versiones de los siguientes servicios:
     - Grafana
     - Prometheus
     - Node-exporter
   - Se agregó grafana-pyroscope a la configuración de Docker Compose para mejorar la visibilidad del rendimiento.

2. **Crear paquete `profiler`:**
   - Se creó un nuevo paquete `profiler` para manejar la inicialización de Pyroscope.
   - El paquete incluye la configuración de Pyroscope para monitorear:
     - CPU
     - Objetos asignados
     - Espacio asignado
     - Objetos en uso
     - Espacio en uso
     - Goroutines
   - Se actualizó `main.go` para utilizar el nuevo paquete `profiler`.

### Cambios

- **docker-compose.yml**:
  - Actualización de versiones de Grafana, Prometheus y Node-exporter.
  - Adición de grafana-pyroscope.
  
- **profiler/profiler.go**:
  - Nuevo archivo para inicialización de Pyroscope.

- **main.go**:
  - Modificación para incluir y utilizar el paquete `profiler`.