### PR TITLE
Agregar CommandExecutor, crear mocks y pruebas para YoutubeFetcher

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,12 +72,13 @@ func main() {
 		return
 	}
 	youtubeService := youtube_provider.NewYouTubeProvider(cfg.YoutubeApiKey, logger, realYouTubeClient)
+	executorCommand := fetcher.NewCommandExecutor()
 
-	youtubeFetcher = fetcher.NewYoutubeFetcher(logger, cacheStorage, cacheMetrics, youtubeService, audioCache)
+	youtubeFetcher = fetcher.NewYoutubeFetcher(logger, cacheStorage, cacheMetrics, youtubeService, audioCache, executorCommand)
 	responseHandler := discord.NewDiscordResponseHandler(logger)
 	sessionService := discord.NewSessionService(dg)
 
-	handler := discord.NewInteractionHandler(ctx, cfg.DiscordToken, responseHandler, sessionService, youtubeFetcher, storage, cfg, logger, commandUsageCounter, cacheStorage, audioCache, cacheMetrics, youtubeService).WithLogger(logger)
+	handler := discord.NewInteractionHandler(ctx, cfg.DiscordToken, responseHandler, sessionService, youtubeFetcher, storage, cfg, logger, commandUsageCounter, cacheStorage, audioCache, cacheMetrics, youtubeService, executorCommand).WithLogger(logger)
 	commandHandler := discord.NewSlashCommandRouter(cfg.CommandPrefix).
 		PlayHandler(handler.PlaySong).
 		SkipHandler(handler.SkipSong).

--- a/internal/discord/interactions.go
+++ b/internal/discord/interactions.go
@@ -41,6 +41,7 @@ type InteractionHandler struct {
 	realYoutubeClient   providers.YouTubeService
 	caching             cache.Manager
 	audioCaching        cache.AudioCaching
+	executorCommand     fetcher.CommandExecutor
 }
 
 // NewInteractionHandler crea una nueva instancia de InteractionHandler.
@@ -51,7 +52,8 @@ func NewInteractionHandler(ctx context.Context, discordToken string, responseHan
 	metricsPrometheus metrics.CustomMetric,
 	manager cache.Manager, audioCaching cache.AudioCaching,
 	cacheMetrics metrics.CacheMetrics,
-	youtubeClient providers.YouTubeService) *InteractionHandler {
+	youtubeClient providers.YouTubeService,
+	executorCommand fetcher.CommandExecutor) *InteractionHandler {
 
 	handler := &InteractionHandler{
 		ctx:                 ctx,
@@ -68,6 +70,7 @@ func NewInteractionHandler(ctx context.Context, discordToken string, responseHan
 		audioCaching:        audioCaching,
 		CacheMetrics:        cacheMetrics,
 		realYoutubeClient:   youtubeClient,
+		executorCommand:     executorCommand,
 	}
 	return handler
 }
@@ -506,7 +509,7 @@ func (handler *InteractionHandler) setupGuildPlayer(guildID GuildID, dg *discord
 	dca := codec.NewDCAStreamerImpl(handler.logger)
 	voiceChat := voice.NewChatSessionImpl(dg, string(guildID), dca, handler.logger)
 	messageSender := discordmessenger.NewMessageSenderImpl(dg, handler.logger)
-	fetcherGetDCA := fetcher.NewYoutubeFetcher(handler.logger, handler.caching, handler.CacheMetrics, handler.realYoutubeClient, handler.audioCaching)
+	fetcherGetDCA := fetcher.NewYoutubeFetcher(handler.logger, handler.caching, handler.CacheMetrics, handler.realYoutubeClient, handler.audioCaching, handler.executorCommand)
 	persistent := file_storage.NewJSONStatePersistent()
 	songStorage, stateStorage := config.GetPlaylistStore(handler.cfg, string(guildID), handler.logger, persistent)
 	player := bot.NewGuildPlayer(handler.ctx, voiceChat, songStorage, stateStorage, fetcherGetDCA.GetDCAData, messageSender, handler.logger).WithLogger(handler.logger)

--- a/internal/music/fetcher/mocks.go
+++ b/internal/music/fetcher/mocks.go
@@ -1,10 +1,12 @@
 package fetcher
 
 import (
+	"context"
 	"github.com/Tomas-vilte/GoMusicBot/internal/discord/voice"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+	"google.golang.org/api/youtube/v3"
 	"time"
 )
 
@@ -117,4 +119,29 @@ func (m *MockCacheManager) Size() int {
 	args := m.Called()
 	size, _ := args.Get(0).(int)
 	return size
+}
+
+type MockYouTubeService struct {
+	mock.Mock
+}
+
+func (m *MockYouTubeService) SearchVideoID(ctx context.Context, searchTerm string) (string, error) {
+	args := m.Called(ctx, searchTerm)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockYouTubeService) GetVideoDetails(ctx context.Context, videoID string) (*youtube.Video, error) {
+	args := m.Called(ctx, videoID)
+	return args.Get(0).(*youtube.Video), args.Error(1)
+}
+
+type MockCommandExecutor struct {
+	mock.Mock
+}
+
+func (m *MockCommandExecutor) ExecuteCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	argsMock := m.Called(ctx, name, args)
+	data, _ := argsMock.Get(0).([]byte)
+	err := argsMock.Error(1)
+	return data, err
 }

--- a/internal/music/fetcher/youtube_fetcher_test.go
+++ b/internal/music/fetcher/youtube_fetcher_test.go
@@ -1,0 +1,359 @@
+package fetcher
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/GoMusicBot/internal/discord/voice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/api/youtube/v3"
+	"testing"
+	"time"
+)
+
+func TestYoutubeFetcher_LookupSongs(t *testing.T) {
+	t.Run("Normal case", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		input := "dQw4w9WgXcQ"
+		videoURL := "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+		thumbnailURL := "https://i3.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+
+		expectedSong := &voice.Song{
+			Type:         "youtube_provider",
+			Title:        "Rick Astley - Never Gonna Give You Up (Official Music Video)",
+			URL:          videoURL,
+			Playable:     true,
+			ThumbnailURL: &thumbnailURL,
+			Duration:     time.Minute*3 + time.Second*33,
+		}
+
+		mockCache.On("Get", videoURL).Return(nil)
+		mockYoutubeService.On("GetVideoDetails", ctx, input).Return(&youtube.Video{
+			Snippet: &youtube.VideoSnippet{
+				Title:                "Rick Astley - Never Gonna Give You Up (Official Music Video)",
+				LiveBroadcastContent: "None",
+				Thumbnails: &youtube.ThumbnailDetails{
+					Default: &youtube.Thumbnail{
+						Url: thumbnailURL,
+					},
+				},
+			},
+			ContentDetails: &youtube.VideoContentDetails{
+				Duration: "PT3M33S",
+			},
+		}, nil)
+		mockCache.On("Set", videoURL, []*voice.Song{expectedSong})
+		mockCache.On("Size").Return(1)
+		mockCacheMetrics.On("IncMisses")
+		mockCacheMetrics.On("SetCacheSize", mock.AnythingOfType("float64"))
+
+		// Act
+		songs, err := fetcher.LookupSongs(ctx, input)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Len(t, songs, 1)
+		assert.Equal(t, expectedSong.Title, songs[0].Title)
+		assert.Equal(t, expectedSong.URL, songs[0].URL)
+		assert.Equal(t, expectedSong.Playable, songs[0].Playable)
+		assert.Equal(t, expectedSong.Duration, songs[0].Duration)
+		assert.Equal(t, expectedSong.ThumbnailURL, songs[0].ThumbnailURL)
+
+		mockCache.AssertExpectations(t)
+		mockYoutubeService.AssertExpectations(t)
+		mockCacheMetrics.AssertExpectations(t)
+		mockLogger.AssertExpectations(t)
+	})
+
+	t.Run("Error fetching video details", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		input := "invalidVideoID"
+		videoURL := fmt.Sprintf("https://www.youtube.com/watch?v=%s", input)
+
+		expectedError := fmt.Errorf("error al obtener detalles del video")
+
+		mockCache.On("Get", videoURL).Return(nil)
+		mockYoutubeService.On("GetVideoDetails", ctx, input).Return(&youtube.Video{}, expectedError)
+		mockLogger.On("Error", "Error al obtener detalles del video", mock.Anything)
+
+		// Act
+		songs, err := fetcher.LookupSongs(ctx, input)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, songs)
+		assert.Equal(t, expectedError.Error(), err.Error())
+
+		mockCache.AssertExpectations(t)
+		mockYoutubeService.AssertExpectations(t)
+		mockLogger.AssertExpectations(t)
+	})
+
+	t.Run("Cached result", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		input := "dQw4w9WgXcQ"
+		videoURL := "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+		thumbnailURL := "https://i3.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+		expectedSong := &voice.Song{
+			Type:         "youtube_provider",
+			Title:        "Rick Astley - Never Gonna Give You Up (Official Music Video)",
+			URL:          videoURL,
+			Playable:     true,
+			ThumbnailURL: &thumbnailURL,
+			Duration:     time.Minute*3 + time.Second*33,
+		}
+		expectedCacheResult := []*voice.Song{expectedSong}
+
+		mockCache.On("Get", videoURL).Return(expectedCacheResult)
+		mockLogger.On("Info", "Video encontrado en cache: ", mock.AnythingOfType("[]zapcore.Field"))
+		mockCacheMetrics.On("IncHits")
+
+		// Act
+		songs, err := fetcher.LookupSongs(ctx, input)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Len(t, songs, 1)
+		assert.Equal(t, expectedSong.Title, songs[0].Title)
+		assert.Equal(t, expectedSong.URL, songs[0].URL)
+		assert.Equal(t, expectedSong.Playable, songs[0].Playable)
+		assert.Equal(t, expectedSong.Duration, songs[0].Duration)
+		assert.Equal(t, expectedSong.ThumbnailURL, songs[0].ThumbnailURL)
+
+		mockCache.AssertExpectations(t)
+		mockLogger.AssertExpectations(t)
+		mockCacheMetrics.AssertExpectations(t)
+		mockYoutubeService.AssertNotCalled(t, "GetVideoDetails", mock.Anything, mock.Anything)
+	})
+}
+
+func TestYoutubeFetcher_GetDCAData(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		song := &voice.Song{
+			URL: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		}
+		expectedData := []byte("fake audio data")
+
+		mockCommandExecutor.On("ExecuteCommand", ctx, "sh", mock.Anything).Return(expectedData, nil)
+		mockAudioCache.On("Get", song.URL).Return(nil, false)
+		mockAudioCache.On("Set", song.URL, expectedData)
+
+		mockCacheMetrics.On("IncRequests").Times(2)
+		mockCacheMetrics.On("IncLatencyGet", mock.Anything)
+		mockCacheMetrics.On("IncLatencySet", mock.Anything)
+
+		// Act
+		reader, err := fetcher.GetDCAData(ctx, song)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, reader)
+
+		mockCommandExecutor.AssertExpectations(t)
+		mockAudioCache.AssertExpectations(t)
+		mockCacheMetrics.AssertExpectations(t)
+	})
+
+	t.Run("Error executing command", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		song := &voice.Song{
+			URL: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		}
+		expectedError := fmt.Errorf("error downloading audio")
+
+		mockCommandExecutor.On("ExecuteCommand", ctx, "sh", mock.Anything).Return(nil, expectedError)
+		mockAudioCache.On("Get", song.URL).Return(nil, false)
+
+		mockCacheMetrics.On("IncRequests")
+		mockCacheMetrics.On("IncLatencyGet", mock.Anything)
+
+		// Act
+		reader, err := fetcher.GetDCAData(ctx, song)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, reader)
+		assert.EqualError(t, err, "error al ejecutar el comando: "+expectedError.Error())
+
+	})
+
+	t.Run("CachedDataAvailable", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		song := &voice.Song{
+			URL: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		}
+		cachedData := []byte("fake cached audio data")
+
+		mockAudioCache.On("Get", song.URL).Return(cachedData, true)
+		mockCacheMetrics.On("IncRequests")
+
+		// Act
+		reader, err := fetcher.GetDCAData(ctx, song)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, reader)
+
+		buffer := make([]byte, len(cachedData))
+		n, err := reader.Read(buffer)
+		assert.NoError(t, err)
+		assert.Equal(t, len(cachedData), n)
+		assert.Equal(t, cachedData, buffer)
+
+		mockAudioCache.AssertExpectations(t)
+		mockCacheMetrics.AssertExpectations(t)
+	})
+
+	t.Run("CachedDataNotAvailable", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		song := &voice.Song{
+			URL: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		}
+
+		mockAudioCache.On("Get", song.URL).Return(nil, false)
+		mockCommandExecutor.On("ExecuteCommand", ctx, "sh", mock.Anything).Return([]byte("fake audio data"), nil)
+		mockAudioCache.On("Set", song.URL, mock.Anything)
+
+		mockCacheMetrics.On("IncRequests").Times(2)
+		mockCacheMetrics.On("IncLatencyGet", mock.Anything)
+		mockCacheMetrics.On("IncLatencySet", mock.Anything)
+
+		// Act
+		reader, err := fetcher.GetDCAData(ctx, song)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, reader)
+
+		mockAudioCache.AssertExpectations(t)
+		mockCacheMetrics.AssertExpectations(t)
+	})
+}
+
+func TestYoutubeFetcher_SearchYouTubeVideoID(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		searchTerm := "Rick Astley Never Gonna Give You Up"
+		expectedVideoID := "dQw4w9WgXcQ"
+
+		mockYoutubeService.On("SearchVideoID", ctx, searchTerm).Return(expectedVideoID, nil)
+
+		// Act
+		videoID, err := fetcher.SearchYouTubeVideoID(ctx, searchTerm)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expectedVideoID, videoID)
+
+		mockYoutubeService.AssertExpectations(t)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Arrange
+		mockLogger := new(MockLogger)
+		mockCache := new(MockCacheManager)
+		mockCacheMetrics := new(MockCacheMetrics)
+		mockYoutubeService := new(MockYouTubeService)
+		mockAudioCache := new(MockAudioCaching)
+		mockCommandExecutor := new(MockCommandExecutor)
+
+		fetcher := NewYoutubeFetcher(mockLogger, mockCache, mockCacheMetrics, mockYoutubeService, mockAudioCache, mockCommandExecutor)
+
+		ctx := context.Background()
+		searchTerm := "Rick Astley Never Gonna Give You Up"
+		expectedError := fmt.Errorf("error buscando el video en YouTube")
+
+		mockYoutubeService.On("SearchVideoID", ctx, searchTerm).Return("", expectedError)
+
+		// Act
+		videoID, err := fetcher.SearchYouTubeVideoID(ctx, searchTerm)
+
+		// Assert
+		assert.Error(t, err)
+		assert.EqualError(t, err, fmt.Sprintf("error al buscar el video en YouTube: %v", expectedError))
+		assert.Empty(t, videoID)
+
+		mockYoutubeService.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
### Descripción

Este PR introduce la interfaz `CommandExecutor` para permitir la ejecución de comandos externos de manera abstracta en `YoutubeFetcher`. Además, se han creado mocks para esta interfaz.
### Cambios Realizados

- Agregada la interfaz `CommandExecutor` en `youtube_fetcher.go` para abstraer la ejecución de comandos.
- Implementados mocks para `CommandExecutor` en `mocks.go` para pruebas unitarias.
- Añadidas pruebas unitarias y de integración para `YoutubeFetcher` en `youtube_fetcher_test.go` para cubrir la nueva funcionalidad.
  - Pruebas para la búsqueda de video ID.
  - Pruebas para la obtención de datos DCA.
  - Pruebas para la verificación y obtención de datos de cache de audio.

### Motivación

Este cambio mejora la estructura del código al introducir abstracciones y facilitar la prueba de las funcionalidades relacionadas con la ejecución de comandos externos en `YoutubeFetcher`. Las pruebas adicionales aseguran el correcto funcionamiento de las nuevas funcionalidades y mocks.

### Notas de Revisión

- Las pruebas pasan exitosamente en entornos de desarrollo local.
- Se han ejecutado y validado los mocks para `CommandExecutor`.
- Se ha verificado la cobertura de pruebas para las nuevas funcionalidades introducidas en `YoutubeFetcher`.
