### PR TITLE
Implementación y pruebas de ClientAPI para procesamiento de metadatos de canciones a través de API Gateway

### DIFF
--- a/internal/discord/service/api.go
+++ b/internal/discord/service/api.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"context"
+	"github.com/Tomas-vilte/GoMusicBot/internal/types"
+)
+
+type (
+	// APIClient esta interface interactua con la API Gateway
+	APIClient interface {
+		ProcessSongMetadata(ctx context.Context, input string) (*types.SongMetadata, error)
+	}
+)

--- a/internal/discord/service/client.go
+++ b/internal/discord/service/client.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/Tomas-vilte/GoMusicBot/internal/logging"
+	"github.com/Tomas-vilte/GoMusicBot/internal/types"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ClientAPI implementa la interfaz APIClient
+type ClientAPI struct {
+	apiGatewayURL string
+	logger        logging.Logger
+	httpClient    *http.Client
+}
+
+// NewClient crea una nueva instancia de ClientAPI
+func NewClient(apiGatewayURL string, logger logging.Logger) APIClient {
+	return &ClientAPI{
+		apiGatewayURL: apiGatewayURL,
+		logger:        logger,
+		httpClient:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// ProcessSongMetadata procesa los metadatos de una canción a través de API Gateway
+func (c *ClientAPI) ProcessSongMetadata(ctx context.Context, input string) (*types.SongMetadata, error) {
+	c.logger.Info("Procesando metadata de la cancion a traves de API Gateway", zap.String("input", input))
+
+	requestBody := map[string]string{
+		"key":  input,
+		"song": input,
+	}
+	responseBody, err := c.makeRequest(ctx, requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("error al procesar la metadata %w", err)
+	}
+
+	var metadata types.SongMetadata
+	if err := json.Unmarshal(responseBody, &metadata); err != nil {
+		c.logger.Error("Error al convertir el cuerpo de la respuesta a JSON", zap.Error(err))
+	}
+
+	return &metadata, nil
+}
+
+func (c *ClientAPI) makeRequest(ctx context.Context, requestBody interface{}) ([]byte, error) {
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		c.logger.Error("Error al convertir el cuerpo de la solicitud a JSON", zap.Error(err))
+		return nil, fmt.Errorf("error al codificar el cuerpo de la solicitud: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiGatewayURL, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		c.logger.Error("Error al crear una nueva solicitud", zap.Error(err))
+		return nil, fmt.Errorf("error al crear la solicitud: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.logger.Error("Error en la solicitud a API Gateway", zap.Error(err))
+		return nil, fmt.Errorf("error en la solicitud a API Gateway: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("Error en la solicitud a API Gateway", zap.Int("status", resp.StatusCode))
+		return nil, fmt.Errorf("error en la solicitud a API Gateway: status code %d", resp.StatusCode)
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("Error al leer el cuerpo de la respuesta", zap.Error(err))
+		return nil, fmt.Errorf("error al leer la respuesta: %w", err)
+	}
+
+	return responseBody, nil
+}

--- a/internal/discord/service/client_test.go
+++ b/internal/discord/service/client_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestProcessSongMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var requestBody map[string]string
+		err := json.NewDecoder(r.Body).Decode(&requestBody)
+		assert.NoError(t, err)
+		assert.Equal(t, "Sean Paul - No Lie ft. Dua Lipa", requestBody["key"])
+		assert.Equal(t, "Sean Paul - No Lie ft. Dua Lipa", requestBody["song"])
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"Type":         "youtube_provider",
+			"Title":        "Sean Paul - No Lie ft. Dua Lipa",
+			"URL":          "https://www.youtube.com/watch?v=GzU8KqOY8YA",
+			"Playable":     true,
+			"ThumbnailURL": "https://i.ytimg.com/vi/GzU8KqOY8YA/default.jpg",
+			"Duration":     229000000000,
+		})
+	}))
+	defer server.Close()
+
+	mockLogger := new(MockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	client := NewClient(server.URL, mockLogger)
+
+	ctx := context.Background()
+	result, err := client.ProcessSongMetadata(ctx, "Sean Paul - No Lie ft. Dua Lipa")
+
+	// Verificar resultados
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "youtube_provider", result.Type)
+	assert.Equal(t, "Sean Paul - No Lie ft. Dua Lipa", result.Title)
+	assert.Equal(t, "https://www.youtube.com/watch?v=GzU8KqOY8YA", result.URL)
+	assert.True(t, result.Playable)
+	assert.Equal(t, "https://i.ytimg.com/vi/GzU8KqOY8YA/default.jpg", result.ThumbnailURL)
+	assert.Equal(t, time.Duration(229000000000), result.Duration)
+
+	mockLogger.AssertCalled(t, "Info", "Procesando metadata de la cancion a traves de API Gateway", mock.Anything)
+}
+
+func TestProcessSongMetadataError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	mockLogger := new(MockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	client := NewClient(server.URL, mockLogger)
+
+	ctx := context.Background()
+	result, err := client.ProcessSongMetadata(ctx, "Sean Paul - No Lie ft. Dua Lipa")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "error en la solicitud a API Gateway: status code 500")
+
+	mockLogger.AssertCalled(t, "Info", "Procesando metadata de la cancion a traves de API Gateway", mock.Anything)
+	mockLogger.AssertCalled(t, "Error", "Error en la solicitud a API Gateway", mock.Anything)
+
+}

--- a/internal/discord/service/client_test.go
+++ b/internal/discord/service/client_test.go
@@ -31,6 +31,7 @@ func TestProcessSongMetadata(t *testing.T) {
 			"ThumbnailURL": "https://i.ytimg.com/vi/GzU8KqOY8YA/default.jpg",
 			"Duration":     229000000000,
 		})
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 

--- a/internal/discord/service/client_test.go
+++ b/internal/discord/service/client_test.go
@@ -23,7 +23,7 @@ func TestProcessSongMetadata(t *testing.T) {
 		assert.Equal(t, "Sean Paul - No Lie ft. Dua Lipa", requestBody["song"])
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		err = json.NewEncoder(w).Encode(map[string]interface{}{
 			"Type":         "youtube_provider",
 			"Title":        "Sean Paul - No Lie ft. Dua Lipa",
 			"URL":          "https://www.youtube.com/watch?v=GzU8KqOY8YA",

--- a/internal/discord/service/mock.go
+++ b/internal/discord/service/mock.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+)
+
+type MockLogger struct {
+	mock.Mock
+}
+
+func (m *MockLogger) Error(msg string, fields ...zap.Field) {
+	m.Called(msg, fields)
+}
+
+func (m *MockLogger) Info(msg string, fields ...zap.Field) {
+	m.Called(msg, fields)
+}
+
+func (m *MockLogger) With(fields ...zap.Field) {
+	m.Called(fields)
+}

--- a/internal/types/song_metadata.go
+++ b/internal/types/song_metadata.go
@@ -1,0 +1,12 @@
+package types
+
+import "time"
+
+type SongMetadata struct {
+	Type         string        `json:"Type"`
+	Title        string        `json:"Title"`
+	URL          string        `json:"URL"`
+	Playable     bool          `json:"Playable"`
+	ThumbnailURL string        `json:"ThumbnailURL"`
+	Duration     time.Duration `json:"Duration"`
+}


### PR DESCRIPTION
### Descripción

Este pull request incluye la implementación de la interfaz `APIClient` y su concreta `ClientAPI`, que interactúa con el API Gateway para procesar metadatos de canciones. La funcionalidad completa permite la interacción con el microservicio encargado de descargar canciones, subirlas a S3 y devolver la metadata correspondiente.

### Cambios Incluidos

1. **Interfaz `APIClient`**
   - Se define la interfaz `APIClient` en `service/api.go`, que incluye el método `ProcessSongMetadata`.

2. **Implementación de `ClientAPI`**
   - Se implementa la interfaz `APIClient` en `service/client_api.go` con la estructura `ClientAPI`.
   - `ClientAPI` maneja la creación de solicitudes HTTP, la comunicación con el API Gateway, y el procesamiento de respuestas.
   - Se añaden métodos para realizar solicitudes HTTP y procesar metadatos de canciones.

3. **Pruebas Unitarias**
   - Se añaden pruebas en `service/client_api_test.go` para verificar el comportamiento de `ClientAPI`.
   - Se incluye un test para verificar el procesamiento correcto de metadatos con un servidor de prueba.
   - Se añade un test para manejar errores durante la solicitud HTTP.

### Notas

- Se utiliza `httptest` para simular el servidor API Gateway durante las pruebas.
- Se ha usado la librería `testify` para facilitar la escritura de pruebas y la simulación del logger.
- Las pruebas aseguran que los metadatos se procesan correctamente y que los errores son manejados apropiadamente.
- Esta implementación es parte de la integración con el microservicio que descarga canciones, las sube a S3 y devuelve la metadata.

### Checklist

- [x] Implementación de `APIClient`
- [x] Implementación de `ClientAPI`
- [x] Pruebas unitarias añadidas
- [x] Documentación actualizada