### PR TITLE
Eliminación de `context.Context` de la estructura `InteractionHandler`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,7 +89,7 @@ func main() {
 	responseHandler := discord.NewDiscordResponseHandler(logger)
 	sessionService := discord.NewSessionService(dg)
 
-	handler := discord.NewInteractionHandler(ctx, cfg.DiscordToken, responseHandler, sessionService, youtubeFetcher, storage, cfg, logger, commandUsageCounter, cacheStorage, audioCache, youtubeService, executorCommand, s3upload).WithLogger(logger)
+	handler := discord.NewInteractionHandler(cfg.DiscordToken, responseHandler, sessionService, youtubeFetcher, storage, cfg, logger, commandUsageCounter, cacheStorage, audioCache, youtubeService, executorCommand, s3upload).WithLogger(logger)
 	commandHandler := discord.NewSlashCommandRouter(cfg.CommandPrefix).
 		PlayHandler(handler.PlaySong).
 		SkipHandler(handler.SkipSong).
@@ -99,7 +99,7 @@ func main() {
 		PlayingNowHandler(handler.GetPlayingSong).
 		AddSongOrPlaylistHandler(handler.AddSongOrPlaylist)
 
-	handler.RegisterEventHandlers(dg)
+	handler.RegisterEventHandlers(dg, ctx)
 	dg.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		switch i.Type {
 		case discordgo.InteractionMessageComponent:
@@ -109,10 +109,10 @@ func main() {
 
 		default:
 			if h, ok := commandHandler.GetCommandHandlers()[i.ApplicationCommandData().Name]; ok {
-				h(s, i)
+				h(ctx, s, i)
 			}
 		}
-		handler.CheckVoiceChannelsPresence()
+		handler.CheckVoiceChannelsPresence(ctx)
 	})
 	dg.Identify.Intents = discordgo.IntentsAll
 	err = dg.Open()

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.4 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.6 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.17.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,9 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.4 h1:9gWcmF85Wvq4ryPFvGFaOgPIs1AQX0d0bcbGw4Z96qg=
 github.com/googleapis/gax-go/v2 v2.12.4/go.mod h1:KYEYLorsnIGDi/rPC8b5TdlB9kbKoFubselGIoBMCwI=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/pyroscope-go v1.1.1 h1:PQoUU9oWtO3ve/fgIiklYuGilvsm8qaGhlY4Vw6MAcQ=
 github.com/grafana/pyroscope-go v1.1.1/go.mod h1:Mw26jU7jsL/KStNSGGuuVYdUq7Qghem5P8aXYXSXG88=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=

--- a/internal/discord/bot/player.go
+++ b/internal/discord/bot/player.go
@@ -35,7 +35,6 @@ type DCADataGetter func(ctx context.Context, song *voice.Song) (io.Reader, error
 
 // GuildPlayer es el reproductor de música para un servidor específico en Discord.
 type GuildPlayer struct {
-	ctx             context.Context                    // Contexto para la gestión de la vida útil del reproductor.
 	triggerCh       chan Trigger                       // Canal para recibir disparadores de comandos relacionados con la reproducción de música.
 	session         voice.VoiceChatSession             // Sesión de chat de voz que define métodos para interactuar con la sesión de voz del bot de Discord.
 	songCtxCancel   context.CancelFunc                 // Función de cancelación del contexto de la canción actual.
@@ -63,9 +62,8 @@ type VoiceChannelInfo struct {
 }
 
 // NewGuildPlayer crea una nueva instancia de GuildPlayer con los parámetros proporcionados.
-func NewGuildPlayer(ctx context.Context, session voice.VoiceChatSession, songStorage store.SongStorage, stateStorage store.StateStorage, dCADataGetter DCADataGetter, message discordmessenger.ChatMessageSender, logger logging.Logger) *GuildPlayer {
+func NewGuildPlayer(session voice.VoiceChatSession, songStorage store.SongStorage, stateStorage store.StateStorage, dCADataGetter DCADataGetter, message discordmessenger.ChatMessageSender, logger logging.Logger) *GuildPlayer {
 	return &GuildPlayer{
-		ctx:             ctx,
 		songStorage:     songStorage,
 		stateStorage:    stateStorage,
 		triggerCh:       make(chan Trigger),

--- a/internal/discord/slash_commands.go
+++ b/internal/discord/slash_commands.go
@@ -1,11 +1,14 @@
 package discord
 
-import "github.com/bwmarrin/discordgo"
+import (
+	"context"
+	"github.com/bwmarrin/discordgo"
+)
 
 // SlashCommandRouter enruta los comandos de barra oblicua en Discord.
 type SlashCommandRouter struct {
 	commandPrefix            string
-	playHandler              func(*discordgo.Session, *discordgo.InteractionCreate, *discordgo.ApplicationCommandInteractionDataOption)
+	playHandler              func(context.Context, *discordgo.Session, *discordgo.InteractionCreate, *discordgo.ApplicationCommandInteractionDataOption)
 	stopHandler              func(*discordgo.Session, *discordgo.InteractionCreate, *discordgo.ApplicationCommandInteractionDataOption)
 	listHandler              func(*discordgo.Session, *discordgo.InteractionCreate, *discordgo.ApplicationCommandInteractionDataOption)
 	skipHandler              func(*discordgo.Session, *discordgo.InteractionCreate, *discordgo.ApplicationCommandInteractionDataOption)
@@ -22,7 +25,7 @@ func NewSlashCommandRouter(commandPrefix string) *SlashCommandRouter {
 }
 
 // PlayHandler establece el manejador para el comando "play".
-func (ch *SlashCommandRouter) PlayHandler(h func(*discordgo.Session, *discordgo.InteractionCreate, *discordgo.ApplicationCommandInteractionDataOption)) *SlashCommandRouter {
+func (ch *SlashCommandRouter) PlayHandler(h func(context.Context, *discordgo.Session, *discordgo.InteractionCreate, *discordgo.ApplicationCommandInteractionDataOption)) *SlashCommandRouter {
 	ch.playHandler = h
 	return ch
 }
@@ -64,15 +67,15 @@ func (ch *SlashCommandRouter) AddSongOrPlaylistHandler(h func(*discordgo.Session
 }
 
 // GetCommandHandlers devuelve los manejadores de los comandos de barra oblicua.
-func (ch *SlashCommandRouter) GetCommandHandlers() map[string]func(*discordgo.Session, *discordgo.InteractionCreate) {
-	return map[string]func(*discordgo.Session, *discordgo.InteractionCreate){
-		ch.commandPrefix: func(s *discordgo.Session, ic *discordgo.InteractionCreate) {
+func (ch *SlashCommandRouter) GetCommandHandlers() map[string]func(context.Context, *discordgo.Session, *discordgo.InteractionCreate) {
+	return map[string]func(context.Context, *discordgo.Session, *discordgo.InteractionCreate){
+		ch.commandPrefix: func(ctx context.Context, s *discordgo.Session, ic *discordgo.InteractionCreate) {
 			options := ic.ApplicationCommandData().Options
 			option := options[0]
 
 			switch option.Name {
 			case "play":
-				ch.playHandler(s, ic, option)
+				ch.playHandler(ctx, s, ic, option)
 			case "stop":
 				ch.stopHandler(s, ic, option)
 			case "list":


### PR DESCRIPTION
## Descripción

Se eliminó el uso de `context.Context` de la estructura `InteractionHandler`. La decisión se tomó porque tener `context.Context` como parte de una estructura es considerado una mala práctica. La razón principal es que el contexto debe ser específico para cada solicitud o proceso, y no compartido entre múltiples instancias o estructuras.

## Cambios Realizados

- Eliminación de `context.Context` de la estructura `InteractionHandler`.
- Ajustes en los métodos y funciones correspondientes para que no dependan del contexto dentro de la estructura.
- Se mantuvieron los principios de diseño que aseguran que cada contexto sea gestionado correctamente dentro de los límites de su ciclo de vida, evitando posibles fugas de recursos o inconsistencias en la ejecución.
