### PR TITLE
Update CD Pipeline to Use Amazon ECR and Deploy Only Discord Bot Service

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,44 +9,36 @@ on:
       - master
 
 jobs:
-  deploy:
-    name: Deploy a EC2
+  build:
+    name: Build Docker Image
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Configurar credenciales de AWS
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-    
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Log in to Amazon ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${{ secrets.AWS_ECR_REPOSITORY }}
 
-      - name: Logearse a Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      
-      - name: Buildear y pushear la imagen
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: dockerfile.aws
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/butakero-bot-aws:latest
-          platforms: linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Build and Push Docker Image to ECR
+        run: |
+          docker build -t ${{ secrets.AWS_ECR_REPOSITORY }}:${{ github.sha }} -f dockerfile.aws .
+          docker push ${{ secrets.AWS_ECR_REPOSITORY }}:${{ github.sha }}
 
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@master
         with:
@@ -56,7 +48,6 @@ jobs:
           script: |
             set -e
             cd /opt/app/ButakeroMusicBotGo
-            git pull
-            docker-compose -f production-docker-compose.yml down
-            docker-compose -f production-docker-compose.yml build
-            docker-compose -f production-docker-compose.yml --env-file .env up -d
+            docker-compose -f production-docker-compose.yml pull
+            docker-compose -f production-docker-compose.yml up -d --no-deps --build discord-bot
+


### PR DESCRIPTION
### Descripción

Este pull request actualiza el pipeline de Continuous Delivery para utilizar Amazon ECR en lugar de Docker Hub y ajusta el despliegue para que solo afecte al servicio del bot de Discord. 

### Cambios Realizados

- **Eliminación de Docker Buildx**: Se ha eliminado la configuración relacionada con Docker Buildx, ya que no es necesario para la construcción de imágenes `arm64`.
- **Actualización del Build y Push de Docker**: Ahora se construye y empuja la imagen Docker directamente a Amazon ECR.
- **Modificación del Despliegue**: El paso de despliegue en el pipeline ahora solo reconstruye y despliega el servicio del bot de Discord (`discord-bot`), dejando los otros servicios intactos.

### Razón de los Cambios

Estos cambios se realizan para simplificar el proceso de despliegue, reducir el tiempo de inactividad y evitar la reconstrucción innecesaria de otros servicios que no necesitan ser actualizados.