### PR TITLE
Add HTML files for Terms of Service, Privacy Policy, and main page for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ButakeroBot</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            width: 80%;
+            margin: auto;
+            overflow: hidden;
+            background: #fff;
+            padding: 20px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+        }
+        a {
+            color: #007bff;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Bienvenido a ButakeroBot</h1>
+        <p>ButakeroBot es un bot de música para Discord que te permite reproducir tus canciones favoritas y obtener recomendaciones personalizadas.</p>
+        <p>Para obtener más información, consulta los siguientes documentos:</p>
+        <ul>
+            <li><a href="terminos-de-servicio.html">Términos de Servicio</a></li>
+            <li><a href="politica-de-privacidad.html">Política de Privacidad</a></li>
+        </ul>
+        <p>Si tienes alguna pregunta, no dudes en contactarnos en <a href="mailto:viltetomas2003@gmail.com">viltetomas2003@gmail.com</a>.</p>
+    </div>
+</body>
+</html>

--- a/politica-de-privacidad.html
+++ b/politica-de-privacidad.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Política de Privacidad - ButakeroBot</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            width: 80%;
+            margin: auto;
+            overflow: hidden;
+            background: #fff;
+            padding: 20px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        h1, h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Política de Privacidad para ButakeroBot</h1>
+
+        <h2>1. Introducción</h2>
+        <p>Esta Política de Privacidad explica cómo <strong>ButakeroBot</strong> recopila, usa y protege la información personal de los usuarios de Discord. Al usar el bot, aceptas las prácticas descritas en esta política.</p>
+
+        <h2>2. Información Recopilada</h2>
+        <ul>
+            <li><strong>Datos Básicos</strong>: Recopilamos información sobre los servidores en los que se utiliza el bot, los usuarios que interactúan con él, y las canciones que se reproducen.</li>
+            <li><strong>Datos Adicionales</strong>: Podemos recopilar datos adicionales para personalizar la experiencia del usuario, como preferencias musicales y patrones de uso.</li>
+        </ul>
+
+        <h2>3. Uso de la Información</h2>
+        <ul>
+            <li><strong>Personalización</strong>: Utilizamos la información recopilada para personalizar recomendaciones musicales y mejorar la experiencia del usuario.</li>
+            <li><strong>Mejora del Servicio</strong>: Usamos los datos para analizar el rendimiento del bot y realizar mejoras.</li>
+        </ul>
+
+        <h2>4. Protección de la Información</h2>
+        <ul>
+            <li><strong>Seguridad</strong>: Implementamos medidas de seguridad para proteger la información personal de los usuarios. Sin embargo, no podemos garantizar una seguridad absoluta.</li>
+            <li><strong>Acceso Restringido</strong>: Solo el personal autorizado tiene acceso a la información recopilada.</li>
+        </ul>
+
+        <h2>5. Compartición de Datos</h2>
+        <ul>
+            <li><strong>Sin Compartición con Terceros</strong>: No compartimos la información personal con terceros, salvo que sea necesario para cumplir con la ley o proteger nuestros derechos.</li>
+        </ul>
+
+        <h2>6. Opciones del Usuario</h2>
+        <ul>
+            <li><strong>Acceso a Datos</strong>: Puedes solicitar acceso a la información que hemos recopilado sobre ti contactándonos en <a href="mailto:viltetomas2003@gmail.com">viltetomas2003@gmail.com</a>.</li>
+            <li><strong>Eliminación de Datos</strong>: Puedes solicitar la eliminación de tus datos contactándonos en <a href="mailto:viltetomas2003@gmail.com">viltetomas2003@gmail.com</a>. La eliminación puede afectar algunas funcionalidades del bot.</li>
+        </ul>
+
+        <h2>7. Cambios en la Política de Privacidad</h2>
+        <ul>
+            <li><strong>Modificaciones</strong>: Podemos actualizar esta Política de Privacidad en cualquier momento. Publicaremos las modificaciones en esta página y te notificaremos sobre los cambios.</li>
+        </ul>
+
+        <h2>8. Ley Aplicable</h2>
+        <p>Esta Política de Privacidad se rige por las leyes de Argentina.</p>
+
+        <h2>9. Contacto</h2>
+        <p>Si tienes preguntas sobre esta Política de Privacidad, contáctanos en <a href="mailto:viltetomas2003@gmail.com">viltetomas2003@gmail.com</a>.</p>
+    </div>
+</body>
+</html>

--- a/terminos-de-servicio.html
+++ b/terminos-de-servicio.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Términos de Servicio - ButakeroBot</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            width: 80%;
+            margin: auto;
+            overflow: hidden;
+            background: #fff;
+            padding: 20px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        h1, h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Términos de Servicio para ButakeroBot</h1>
+
+        <h2>1. Introducción</h2>
+        <p>Bienvenido a <strong>ButakeroBot</strong>. Al usar nuestro bot de música en Discord, aceptas estos Términos de Servicio. Si no estás de acuerdo con alguno de estos términos, por favor, no uses el bot.</p>
+
+        <h2>2. Uso del Bot</h2>
+        <ul>
+            <li><strong>Acceso y Uso</strong>: El bot está diseñado para reproducir música en servidores de Discord. Debes usar el bot de acuerdo con las políticas de Discord y las leyes aplicables.</li>
+            <li><strong>Propósito</strong>: <strong>ButakeroBot</strong> ofrece funcionalidades de reproducción de música y puede incluir características adicionales, como recomendaciones personalizadas. Algunas de estas características pueden ser pagas.</li>
+            <li><strong>Restricciones</strong>: No debes usar el bot para reproducir música de manera ilegal o para realizar actividades que infrinjan los derechos de autor u otros derechos de propiedad.</li>
+        </ul>
+
+        <h2>3. Privacidad y Datos</h2>
+        <ul>
+            <li><strong>Datos Recopilados</strong>: 
+                <ul>
+                    <li><strong>Datos Básicos</strong>: Recopilamos información sobre los servidores en los que se utiliza el bot, los usuarios que interactúan con él, y las canciones que se reproducen.</li>
+                    <li><strong>Datos Adicionales</strong>: En el futuro, podemos recopilar datos adicionales para personalizar la experiencia de usuario, como preferencias musicales y patrones de uso.</li>
+                </ul>
+            </li>
+            <li><strong>Uso de los Datos</strong>: Los datos recopilados se utilizarán para personalizar recomendaciones musicales, mejorar el rendimiento del bot y proporcionar una mejor experiencia de usuario.</li>
+            <li><strong>Protección de Datos</strong>: Nos comprometemos a proteger tu información personal. Implementamos medidas de seguridad para resguardar los datos, pero no podemos garantizar una seguridad absoluta.</li>
+        </ul>
+
+        <h2>4. Características Pagas</h2>
+        <ul>
+            <li><strong>Servicios Premium</strong>: Algunas características del bot pueden estar disponibles solo a través de suscripciones o pagos únicos. Los detalles sobre estos servicios pagados se proporcionarán en el bot o en nuestra página web.</li>
+            <li><strong>Pago y Facturación</strong>: Los pagos se procesarán a través de plataformas de pago en línea. No garantizamos la disponibilidad continua de los servicios pagos y nos reservamos el derecho de modificar o eliminar estos servicios en cualquier momento.</li>
+        </ul>
+
+        <h2>5. Derechos de Propiedad</h2>
+        <ul>
+            <li><strong>Propiedad del Bot</strong>: Todos los derechos sobre <strong>ButakeroBot</strong> y su código fuente pertenecen a Thomas Ezequiel Vilte.</li>
+            <li><strong>Licencia de Uso</strong>: Se te otorga una licencia limitada, no exclusiva y revocable para usar el bot según estos Términos de Servicio.</li>
+        </ul>
+
+        <h2>6. Modificaciones y Terminación</h2>
+        <ul>
+            <li><strong>Cambios</strong>: Podemos modificar estos Términos de Servicio en cualquier momento. Te notificaremos sobre los cambios y se te pedirá que los aceptes para continuar usando el bot.</li>
+            <li><strong>Terminación</strong>: Nos reservamos el derecho de suspender o terminar el acceso al bot si violas estos términos.</li>
+        </ul>
+
+        <h2>7. Exención de Responsabilidad</h2>
+        <p>No somos responsables de ningún daño directo, indirecto, incidental o consecuente que surja del uso del bot.</p>
+
+        <h2>8. Ley Aplicable</h2>
+        <p>Estos términos se rigen por las leyes de Argentina.</p>
+
+        <h2>9. Contacto</h2>
+        <p>Si tienes preguntas sobre estos Términos de Servicio, contáctanos en <a href="mailto:viltetomas2003@gmail.com">viltetomas2003@gmail.com</a>.</p>
+
+        <h2>10. Código Fuente</h2>
+        <p>Puedes consultar el código fuente del bot en nuestro repositorio de GitHub: <a href="https://github.com/Tomas-vilte/ButakeroMusicBotGo" target="_blank">https://github.com/Tomas-vilte/ButakeroMusicBotGo</a>.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Este Pull Request incluye las siguientes actualizaciones:
- Se ha agregado `index.html` como la página principal del sitio web.
- Se han añadido `terminos-de-servicio.html` para los Términos de Servicio.
- Se ha añadido `politica-de-privacidad.html` para la Política de Privacidad.

Estos cambios configuran el sitio web para su publicación en GitHub Pages y proporcionan los documentos legales necesarios para los usuarios.
