### PR TITLE
Add Opus Frame Decoder with Metadata Handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aws/aws-sdk-go v1.55.3
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/grafana/pyroscope-go v1.1.2
-	github.com/jogramming/dca v0.0.0-20210930103944-155f5e5f0cc7
 	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
@@ -33,7 +32,6 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/jonas747/ogg v0.0.0-20161220051205-b4f6f4cf3757 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,10 +76,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/jogramming/dca v0.0.0-20210930103944-155f5e5f0cc7 h1:3nT2dRfYYlVBofXRG2WECKHDN5nwL22oyeBTClAONzU=
-github.com/jogramming/dca v0.0.0-20210930103944-155f5e5f0cc7/go.mod h1:dxkp/IJD9cJBPedO7O+wWDidThTNKcl5/AkIbvLV5mE=
-github.com/jonas747/ogg v0.0.0-20161220051205-b4f6f4cf3757 h1:Kyv+zTfWIGRNaz/4+lS+CxvuKVZSKFz/6G8E3BKKBRs=
-github.com/jonas747/ogg v0.0.0-20161220051205-b4f6f4cf3757/go.mod h1:cZnNmdLiLpihzgIVqiaQppi9Ts3D4qF/M45//yW35nI=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -1,0 +1,92 @@
+package decoder
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/Tomas-vilte/GoMusicBot/internal/types"
+)
+
+// Decoder es una estructura que proporciona métodos para leer y procesar datos de un flujo de entrada.
+type Decoder struct {
+	r                   io.Reader       // Reader que lee datos del flujo de entrada
+	Metadata            *types.Metadata // Metadatos leídos del flujo
+	firstFrameProcessed bool            // Indica si el primer marco ha sido procesado
+}
+
+// NewDecoder crea una nueva instancia de Decoder, inicializando el Reader con un bufio.Reader para un buffering eficiente.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{
+		r: bufio.NewReader(r),
+	}
+}
+
+// ReadMetadata lee y procesa los metadatos del flujo de entrada. Este método debe ser llamado antes de leer cualquier marco de datos.
+func (d *Decoder) ReadMetadata() error {
+	if d.firstFrameProcessed {
+		return ErrNotFirstFrame // Retorna un error si el primer marco ya ha sido procesado
+	}
+	d.firstFrameProcessed = true
+
+	// Lee los primeros 4 bytes del flujo, que se utilizan para determinar el tamaño de los metadatos
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(d.r, header); err != nil {
+		return err // Retorna un error si no se pudieron leer los 4 bytes
+	}
+
+	// Lee el tamaño de los metadatos
+	var metaLen int32
+	if err := binary.Read(d.r, binary.LittleEndian, &metaLen); err != nil {
+		return err // Retorna un error si no se pudo leer el tamaño de los metadatos
+	}
+
+	// Lee los metadatos basados en el tamaño leído
+	jsonBuf := make([]byte, metaLen)
+	if _, err := io.ReadFull(d.r, jsonBuf); err != nil {
+		return err // Retorna un error si no se pudieron leer los metadatos
+	}
+
+	// Deserializa los metadatos en la estructura Metadata
+	d.Metadata = new(types.Metadata)
+	return json.Unmarshal(jsonBuf, d.Metadata)
+}
+
+// OpusFrame lee y decodifica un marco Opus del flujo de entrada. Si es la primera vez que se llama, también lee los metadatos.
+func (d *Decoder) OpusFrame() ([]byte, error) {
+	if !d.firstFrameProcessed {
+		if err := d.ReadMetadata(); err != nil {
+			return nil, err // Retorna un error si no se pudieron leer los metadatos
+		}
+	}
+	return DecodeFrame(d.r) // Lee y decodifica un marco Opus
+}
+
+// FrameDuration devuelve la duración del marco en función de los metadatos. Si no hay metadatos, devuelve una duración predeterminada de 20 ms.
+func (d *Decoder) FrameDuration() time.Duration {
+	if d.Metadata == nil {
+		return 20 * time.Millisecond // Valor predeterminado si no hay metadatos
+	}
+	return time.Duration(((d.Metadata.Opus.FrameSize/d.Metadata.Opus.Channels)/960)*20) * time.Millisecond
+}
+
+// DecodeFrame lee y decodifica un marco del flujo de entrada. El tamaño del marco se lee como un entero de 16 bits.
+func DecodeFrame(r io.Reader) ([]byte, error) {
+	var size int16
+	if err := binary.Read(r, binary.LittleEndian, &size); err != nil {
+		return nil, err // Retorna un error si no se pudo leer el tamaño del marco
+	}
+
+	if size < 0 {
+		return nil, ErrNegativeFrameSize // Retorna un error si el tamaño del marco es negativo
+	}
+
+	frame := make([]byte, size)
+	if _, err := io.ReadFull(r, frame); err != nil {
+		return nil, err // Retorna un error si no se pudo leer el marco
+	}
+
+	return frame, nil
+}

--- a/internal/decoder/errors.go
+++ b/internal/decoder/errors.go
@@ -1,0 +1,10 @@
+package decoder
+
+import "errors"
+
+var (
+	ErrNotDCA            = errors.New("No se encontró el encabezado mágico DCA, puede que no sea un archivo DCA o que contenga tramas DCA en bruto")
+	ErrNotFirstFrame     = errors.New("La metadata solo puede encontrarse en el primer marco")
+	ErrInvalidMetaLen    = errors.New("Longitud de metadata inválida")
+	ErrNegativeFrameSize = errors.New("Tamaño del marco es negativo, posiblemente está corrupto")
+)


### PR DESCRIPTION
### Descripción

Este PR introduce una nueva estructura `Decoder` para leer y procesar marcos Opus desde un flujo de entrada, junto con el manejo de metadatos. El `Decoder` proporciona métodos para leer metadatos, decodificar marcos Opus y calcular la duración de los marcos basada en los metadatos.

### Cambios

- **Estructura `Decoder`**: Se añadió una nueva estructura `Decoder` con métodos para procesar marcos Opus y metadatos.
  - **`NewDecoder`**: Inicializa un `Decoder` con un lector con buffer para un streaming eficiente.
  - **`ReadMetadata`**: Lee y procesa los metadatos del flujo de entrada. Debe ser llamada antes de leer cualquier marco.
  - **`OpusFrame`**: Lee y decodifica un marco Opus. Asegura que los metadatos sean leídos primero si aún no se han procesado.
  - **`FrameDuration`**: Calcula la duración del marco basada en los metadatos o devuelve un valor por defecto si no hay metadatos disponibles.

- **Función `DecodeFrame`**: Se añadió una función auxiliar para leer y decodificar un marco Opus desde el flujo de entrada. Maneja el tamaño del marco y errores.