### PR TITLE
Add OAuth2 Authentication Support to Docker and YoutubeFetcher

### DIFF
--- a/dockerfile.aws
+++ b/dockerfile.aws
@@ -1,39 +1,3 @@
-# FROM --platform=linux/arm64 arm64v8/golang:1.21-alpine3.18 AS builder
-
-# # Instalar dependencias necesarias
-# RUN apk add --no-cache build-base opus-dev opusfile-dev \
-#     && go install github.com/bwmarrin/dca/cmd/dca@latest
-
-# WORKDIR /src/
-# COPY go.mod go.sum ./
-# RUN go mod download
-# COPY cmd/ cmd/
-# COPY internal/ internal/
-# RUN CGO_ENABLED=1 GOARCH=arm64 GOMAXPROCS=4 go build -ldflags="-s -w" -o /bin/butakero cmd/main.go
-
-# # Etapa final del contenedor
-# FROM --platform=linux/arm64 arm64v8/alpine:edge
-
-# ENV DISCORD_TOKEN=
-# ENV COMMAND_PREFIX=
-# ENV YOUTUBE_API_KEY=
-# ENV BUCKET_NAME=
-# ENV REGION=
-# ENV ACCESS_KEY=
-# ENV SECRET_KEY=
-
-# # Instalar dependencias necesarias para la ejecución
-# RUN apk add --no-cache ffmpeg wget opusfile yt-dlp \
-#     && apk add --no-cache gcompat libstdc++ \
-#     # Actualizar yt-dlp
-#     && apk -U upgrade yt-dlp
-
-# # Copiar los binarios compilados desde la etapa de construcción
-# COPY --from=builder /bin/butakero /bin/butakero
-# COPY --from=builder /go/bin/dca /usr/local/bin/dca
-
-# CMD ["/bin/butakero"]
-
 # Usar la imagen base de Golang con Alpine para arquitectura amd64
 FROM --platform=linux/amd64 golang:1.21-alpine3.18 AS builder
 
@@ -67,19 +31,23 @@ ENV BUCKET_NAME=
 ENV REGION=
 ENV ACCESS_KEY=
 ENV SECRET_KEY=
-ENV USERNAME=
-ENV PASSOWRD=
 
 # Instalar las dependencias necesarias para la ejecución del binario
-RUN apk add --no-cache ffmpeg wget opusfile yt-dlp \
-    && apk add --no-cache gcompat libstdc++ \
-    # Actualizar yt-dlp a la última versión
-    && apk -U upgrade yt-dlp
+RUN apk add --no-cache ffmpeg wget opusfile python3 py3-pip \
+    # Crear un entorno virtual y activar el entorno
+    && python3 -m venv /venv \
+    && /venv/bin/pip install --upgrade pip \
+    # Instalar yt-dlp y el plugin OAuth2 en el entorno virtual
+    && /venv/bin/pip install yt-dlp \
+    && /venv/bin/pip install -U https://github.com/coletdjnz/yt-dlp-youtube-oauth2/archive/refs/heads/master.zip
 
 # Copiar el binario compilado desde la etapa de construcción
 COPY --from=builder /bin/butakero /bin/butakero
 # Copiar la herramienta dca compilada desde la etapa de construcción
 COPY --from=builder /go/bin/dca /usr/local/bin/dca
+
+# Establecer el entorno virtual como el predeterminado para los comandos
+ENV PATH="/venv/bin:$PATH"
 
 # Definir el comando de inicio del contenedor
 CMD ["/bin/butakero"]

--- a/dockerfile.local
+++ b/dockerfile.local
@@ -1,3 +1,4 @@
+# Usar la imagen base de Golang con Alpine para arquitectura amd64
 FROM --platform=linux/amd64 golang:1.21-alpine3.18 AS builder
 
 # Instalar las dependencias necesarias para la compilación
@@ -30,19 +31,23 @@ ENV BUCKET_NAME=
 ENV REGION=
 ENV ACCESS_KEY=
 ENV SECRET_KEY=
-ENV USERNAME=
-ENV PASSOWRD=
 
 # Instalar las dependencias necesarias para la ejecución del binario
-RUN apk add --no-cache ffmpeg wget opusfile yt-dlp \
-    && apk add --no-cache gcompat libstdc++ \
-    # Actualizar yt-dlp a la última versión
-    && apk -U upgrade yt-dlp
+RUN apk add --no-cache ffmpeg wget opusfile python3 py3-pip \
+    # Crear un entorno virtual y activar el entorno
+    && python3 -m venv /venv \
+    && /venv/bin/pip install --upgrade pip \
+    # Instalar yt-dlp y el plugin OAuth2 en el entorno virtual
+    && /venv/bin/pip install yt-dlp \
+    && /venv/bin/pip install -U https://github.com/coletdjnz/yt-dlp-youtube-oauth2/archive/refs/heads/master.zip
 
 # Copiar el binario compilado desde la etapa de construcción
 COPY --from=builder /bin/butakero /bin/butakero
 # Copiar la herramienta dca compilada desde la etapa de construcción
 COPY --from=builder /go/bin/dca /usr/local/bin/dca
+
+# Establecer el entorno virtual como el predeterminado para los comandos
+ENV PATH="/venv/bin:$PATH"
 
 # Definir el comando de inicio del contenedor
 CMD ["/bin/butakero"]

--- a/internal/music/fetcher/youtube_fetcher.go
+++ b/internal/music/fetcher/youtube_fetcher.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Tomas-vilte/GoMusicBot/internal/storage/s3_audio"
 	"go.uber.org/zap"
 	"io"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -36,8 +35,8 @@ type (
 		S3Uploader      s3_audio.Uploader
 
 		// Esto es para uso temporal! Debido a que youtube pide oauth, ademas con esto podemos evitar baneamiento de IP
-		username string
-		password string
+		//username string
+		//password string
 	}
 
 	// CommandExecutor define una interfaz para ejecutar comandos del sistema.
@@ -65,8 +64,6 @@ func NewYoutubeFetcher(logger logging.Logger, cache cache.Manager, youtubeServic
 		audioCache:      audioCache,
 		CommandExecutor: commandExecutor,
 		S3Uploader:      s3Upload,
-		username:        os.Getenv("USERNAME"),
-		password:        os.Getenv("PASSWORD"),
 	}
 }
 
@@ -214,7 +211,7 @@ func (s *YoutubeFetcher) GetDCAData(ctx context.Context, song *voice.Song) (io.R
 }
 
 func (s *YoutubeFetcher) downloadAndStreamAudio(ctx context.Context, song *voice.Song, writer io.Writer) error {
-	ytArgs := []string{"-f", "bestaudio[ext=m4a]", "--audio-quality", "0", "-o", "-", "--force-overwrites", "--http-chunk-size", "100K", "-u", s.username, "-p", s.password, song.URL}
+	ytArgs := []string{"-f", "bestaudio[ext=m4a]", "--audio-quality", "0", "-o", "-", "--force-overwrites", "--http-chunk-size", "100K", "--username", "oauth2", "--password", "''", song.URL}
 	ffmpegArgs := []string{"-i", "pipe:0", "-b:a", "192k", "-f", "s16le", "-ar", "48000", "-ac", "2", "pipe:1"}
 
 	cmd := s.CommandExecutor.ExecuteCommand(ctx, "sh", "-c", fmt.Sprintf("yt-dlp %s | ffmpeg %s | dca",


### PR DESCRIPTION
Este PR incluye los siguientes cambios:

- **Dockerfiles:** Actualización de los Dockerfiles locales y de AWS para instalar `yt-dlp` y el plugin OAuth2 usando `pip` en un entorno virtual.
- **Código de YoutubeFetcher:** Modificación del código para usar los nuevos argumentos `--username oauth2 --password ''` para la autenticación OAuth2 con `yt-dlp`.

Estos cambios permiten que el bot de música de Discord utilice la autenticación OAuth2 para acceder a YouTube de manera más segura y eficiente.
