### PR TITLE
Implement OperationStore with CRUD Operations and Add Unit/Integration Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
           REGION: ${{ secrets.REGION }}
+          DYNAMODB_TABLE_NAME: ${{ secrets.DYNAMODB_TABLE_NAME }}
+          DYNAMODB_TABLE_NAME_OPERATION: ${{ secrets.DYNAMODB_TABLE_NAME_OPERATION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: make integration-test

--- a/microservices/audio_processor/internal/domain/model/metadata.go
+++ b/microservices/audio_processor/internal/domain/model/metadata.go
@@ -7,6 +7,7 @@ type Metadata struct {
 	Duration       int    `json:"duration"`        // Duración de la canción en segundos.
 	URLS3          string `json:"url_s3"`          // URL del archivo almacenado en S3.
 	URLYouTube     string `json:"url_youtube"`     // URL de la canción en YouTube.
+	Thumbnail      string `json:"thumbnail"`       // Imagen del contenido
 	DownloadDate   string `json:"download_date"`   // Fecha en que se descargó la canción.
 	Platform       string `json:"platform"`        // Plataforma de origen (e.g., YouTube).
 	ProcessingDate string `json:"processing_date"` // Fecha en que se procesó la canción.

--- a/microservices/audio_processor/internal/domain/model/metadata.go
+++ b/microservices/audio_processor/internal/domain/model/metadata.go
@@ -1,17 +1,37 @@
 package model
 
+// Metadata representa la información sobre una canción procesada.
+// Contiene detalles sobre la canción, como su título, artista, duración, y URLs de recursos.
 type Metadata struct {
-	ID             string `json:"id"`              // Identificador único de la canción.
-	Title          string `json:"title"`           // Título de la canción.
-	Artist         string `json:"artist"`          // Artista de la canción.
-	Duration       int    `json:"duration"`        // Duración de la canción en segundos.
-	URLS3          string `json:"url_s3"`          // URL del archivo almacenado en S3.
-	URLYouTube     string `json:"url_youtube"`     // URL de la canción en YouTube.
-	Thumbnail      string `json:"thumbnail"`       // Imagen del contenido
-	DownloadDate   string `json:"download_date"`   // Fecha en que se descargó la canción.
-	Platform       string `json:"platform"`        // Plataforma de origen (e.g., YouTube).
-	ProcessingDate string `json:"processing_date"` // Fecha en que se procesó la canción.
-	Success        bool   `json:"success"`         // Indica si el procesamiento fue exitoso.
-	Attempts       int    `json:"attempts"`        // Número de intentos para descargar o procesar la canción.
-	Failures       int    `json:"failures"`        // Número de fallos durante el proceso.
+	// ID es un identificador único para la canción.
+	// Este campo se utiliza para asociar la metadata con una canción específica.
+	ID string `json:"id"`
+
+	// Title es el título de la canción.
+	// Representa el nombre de la canción tal como aparece en la fuente de origen.
+	Title string `json:"title"`
+
+	// Artist es el nombre del artista o grupo que interpreta la canción.
+	// Este campo ayuda a identificar el creador de la música.
+	Artist string `json:"artist"`
+
+	// Duration es la duración de la canción en segundos.
+	// Representa cuánto tiempo dura la canción desde el inicio hasta el final.
+	Duration int `json:"duration"`
+
+	// URLS3 es la URL del archivo de la canción almacenado en Amazon S3.
+	// Este campo se usa para acceder al archivo de audio descargado y procesado.
+	URLS3 string `json:"url_s3"`
+
+	// URLYouTube es la URL de la canción en YouTube.
+	// Permite localizar la canción en YouTube para referencias adicionales o reproducción.
+	URLYouTube string `json:"url_youtube"`
+
+	// Thumbnail es la imagen en miniatura del contenido.
+	// Proporciona una vista previa visual de la canción, útil para interfaces de usuario y presentación.
+	Thumbnail string `json:"thumbnail"`
+
+	// Platform indica la plataforma de origen de la canción (e.g., YouTube).
+	// Este campo identifica la fuente desde la cual se obtuvo la canción.
+	Platform string `json:"platform"`
 }

--- a/microservices/audio_processor/internal/domain/model/operation.go
+++ b/microservices/audio_processor/internal/domain/model/operation.go
@@ -1,9 +1,43 @@
 package model
 
+// OperationResult representa el resultado de una operación de procesamiento de canción.
+// Contiene información sobre la canción procesada, el estado de la operación,
+// y estadísticas de éxito y fallos.
 type OperationResult struct {
-	ID      string `json:"id"`
-	SongID  string `json:"song_id"`
-	Status  string `json:"status"`
+	// ID es un identificador único para el resultado de la operación.
+	// Se genera utilizando UUID para asegurar que cada resultado tenga una clave única.
+	ID string `json:"id"`
+
+	// SongID es el identificador único de la canción que se está procesando.
+	// Este ID se utiliza para asociar el resultado de la operación con una canción específica.
+	SongID string `json:"song_id"`
+
+	// Status indica el estado actual de la operación.
+	// Puede tener valores como "In Progress", "Completed", "Failed", etc.
+	Status string `json:"status"`
+
+	// Message contiene un mensaje descriptivo relacionado con el resultado de la operación.
+	// Puede incluir detalles de errores o mensajes de éxito.
 	Message string `json:"message"`
-	Data    string `json:"data"`
+
+	// Data es un campo opcional que puede contener información adicional sobre la operación.
+	// Generalmente se utiliza para almacenar datos relacionados con el procesamiento de la canción,
+	// como el tamaño del archivo, duración, etc.
+	Data string `json:"data"`
+
+	// ProcessingDate es la fecha en la que se procesó la canción.
+	// Se utiliza para registrar cuándo se completó el procesamiento.
+	ProcessingDate string `json:"processing_date"`
+
+	// Success indica si el procesamiento de la canción fue exitoso o no.
+	// Es un campo booleano que puede ser true o false.
+	Success bool `json:"success"`
+
+	// Attempts es el número de intentos realizados para descargar o procesar la canción.
+	// Se incrementa cada vez que se intenta realizar la operación.
+	Attempts int `json:"attempts"`
+
+	// Failures es el número de fallos ocurridos durante el proceso de descarga o procesamiento.
+	// Se utiliza para registrar y monitorizar los problemas encontrados.
+	Failures int `json:"failures"`
 }

--- a/microservices/audio_processor/internal/domain/model/operation.go
+++ b/microservices/audio_processor/internal/domain/model/operation.go
@@ -1,0 +1,9 @@
+package model
+
+type OperationResult struct {
+	ID      string `json:"id"`
+	SongID  string `json:"song_id"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Data    string `json:"data"`
+}

--- a/microservices/audio_processor/internal/infrastructure/dynamodbservice/metadata_store.go
+++ b/microservices/audio_processor/internal/infrastructure/dynamodbservice/metadata_store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
-	"time"
 )
 
 type (
@@ -51,26 +50,19 @@ func (s *MetadataStore) SaveMetadata(ctx context.Context, metadata model.Metadat
 		metadata.ID = uuid.New().String()
 	}
 
-	downloadDate := metadata.DownloadDate
-	if downloadDate == "" {
-		downloadDate = time.Now().Format(time.RFC3339)
-	}
-
 	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(s.TableName),
 		Item: map[string]types.AttributeValue{
-			"PK":           &types.AttributeValueMemberS{Value: "METADATA#" + metadata.ID},
-			"SK":           &types.AttributeValueMemberS{Value: "METADATA#" + metadata.ID},
-			"ID":           &types.AttributeValueMemberS{Value: metadata.ID},
-			"Title":        &types.AttributeValueMemberS{Value: metadata.Title},
-			"URLYoutube":   &types.AttributeValueMemberS{Value: metadata.URLYouTube},
-			"URLS3":        &types.AttributeValueMemberS{Value: metadata.URLS3},
-			"Platform":     &types.AttributeValueMemberS{Value: metadata.Platform},
-			"DownloadDate": &types.AttributeValueMemberS{Value: downloadDate},
-			"Attempts":     &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", metadata.Attempts)},
-			"Failures":     &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", metadata.Failures)},
-			"Artist":       &types.AttributeValueMemberS{Value: metadata.Artist},
-			"Duration":     &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", metadata.Duration)},
+			"PK":         &types.AttributeValueMemberS{Value: "METADATA#" + metadata.ID},
+			"SK":         &types.AttributeValueMemberS{Value: "METADATA#" + metadata.ID},
+			"ID":         &types.AttributeValueMemberS{Value: metadata.ID},
+			"Title":      &types.AttributeValueMemberS{Value: metadata.Title},
+			"URLYoutube": &types.AttributeValueMemberS{Value: metadata.URLYouTube},
+			"Thumbnail":  &types.AttributeValueMemberS{Value: metadata.Thumbnail},
+			"URLS3":      &types.AttributeValueMemberS{Value: metadata.URLS3},
+			"Platform":   &types.AttributeValueMemberS{Value: metadata.Platform},
+			"Artist":     &types.AttributeValueMemberS{Value: metadata.Artist},
+			"Duration":   &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", metadata.Duration)},
 		},
 	})
 	if err != nil {

--- a/microservices/audio_processor/internal/infrastructure/dynamodbservice/operation_store.go
+++ b/microservices/audio_processor/internal/infrastructure/dynamodbservice/operation_store.go
@@ -12,18 +12,21 @@ import (
 	"github.com/google/uuid"
 )
 
+// OperationStore maneja el almacenamiento, recuperación y eliminación de resultados de operación en DynamoDB.
 type OperationStore struct {
-	Client    DynamoDBAPI
-	TableName string
+	Client    DynamoDBAPI // Cliente para interactuar con DynamoDB.
+	TableName string      // Nombre de la tabla en DynamoDB.
 }
 
+// NewOperationStore crea una nueva instancia de OperationStore con la configuración proporcionada.
 func NewOperationStore(tableName string, region string) (*OperationStore, error) {
+	// Carga la configuración de AWS con la región especificada.
 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
 	if err != nil {
 		return nil, fmt.Errorf("error cargando configuración AWS: %w", err)
-
 	}
 
+	// Crea un nuevo cliente de DynamoDB.
 	client := dynamodb.NewFromConfig(cfg)
 
 	return &OperationStore{
@@ -32,21 +35,26 @@ func NewOperationStore(tableName string, region string) (*OperationStore, error)
 	}, nil
 }
 
+// SaveOperationResult guarda el resultado de una operación en DynamoDB. Genera un nuevo ID si es necesario.
 func (s *OperationStore) SaveOperationResult(ctx context.Context, result model.OperationResult) error {
 	if result.ID == "" {
-		result.ID = uuid.New().String()
+		result.ID = uuid.New().String() // Genera un nuevo ID si es necesario.
 	}
 
 	input := &dynamodb.PutItemInput{
 		TableName: aws.String(s.TableName),
 		Item: map[string]types.AttributeValue{
-			"PK":      &types.AttributeValueMemberS{Value: "OPERATION#" + result.ID},
-			"SK":      &types.AttributeValueMemberS{Value: result.SongID},
-			"ID":      &types.AttributeValueMemberS{Value: result.ID},
-			"SongID":  &types.AttributeValueMemberS{Value: result.SongID},
-			"Status":  &types.AttributeValueMemberS{Value: result.Status},
-			"Message": &types.AttributeValueMemberS{Value: result.Message},
-			"Data":    &types.AttributeValueMemberS{Value: result.Data},
+			"PK":             &types.AttributeValueMemberS{Value: "OPERATION#" + result.ID},
+			"SK":             &types.AttributeValueMemberS{Value: result.SongID},
+			"ID":             &types.AttributeValueMemberS{Value: result.ID},
+			"SongID":         &types.AttributeValueMemberS{Value: result.SongID},
+			"Status":         &types.AttributeValueMemberS{Value: result.Status},
+			"Message":        &types.AttributeValueMemberS{Value: result.Message},
+			"Data":           &types.AttributeValueMemberS{Value: result.Data},
+			"ProcessingDate": &types.AttributeValueMemberS{Value: result.ProcessingDate},
+			"Success":        &types.AttributeValueMemberBOOL{Value: result.Success},
+			"Attempts":       &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", result.Attempts)},
+			"Failures":       &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", result.Failures)},
 		},
 	}
 
@@ -57,6 +65,7 @@ func (s *OperationStore) SaveOperationResult(ctx context.Context, result model.O
 	return nil
 }
 
+// GetOperationResult recupera el resultado de una operación desde DynamoDB usando el ID y el SongID proporcionados.
 func (s *OperationStore) GetOperationResult(ctx context.Context, id, songID string) (*model.OperationResult, error) {
 	input := &dynamodb.GetItemInput{
 		TableName: aws.String(s.TableName),
@@ -82,6 +91,7 @@ func (s *OperationStore) GetOperationResult(ctx context.Context, id, songID stri
 	return &result, nil
 }
 
+// DeleteOperationResult elimina el resultado de una operación de DynamoDB usando el ID y el SongID proporcionados.
 func (s *OperationStore) DeleteOperationResult(ctx context.Context, id, songID string) error {
 	input := &dynamodb.DeleteItemInput{
 		TableName: aws.String(s.TableName),

--- a/microservices/audio_processor/internal/infrastructure/dynamodbservice/operation_store.go
+++ b/microservices/audio_processor/internal/infrastructure/dynamodbservice/operation_store.go
@@ -1,0 +1,98 @@
+package dynamodbservice
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/uuid"
+)
+
+type OperationStore struct {
+	Client    DynamoDBAPI
+	TableName string
+}
+
+func NewOperationStore(tableName string, region string) (*OperationStore, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("error cargando configuración AWS: %w", err)
+
+	}
+
+	client := dynamodb.NewFromConfig(cfg)
+
+	return &OperationStore{
+		Client:    client,
+		TableName: tableName,
+	}, nil
+}
+
+func (s *OperationStore) SaveOperationResult(ctx context.Context, result model.OperationResult) error {
+	if result.ID == "" {
+		result.ID = uuid.New().String()
+	}
+
+	input := &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]types.AttributeValue{
+			"PK":      &types.AttributeValueMemberS{Value: "OPERATION#" + result.ID},
+			"SK":      &types.AttributeValueMemberS{Value: result.SongID},
+			"ID":      &types.AttributeValueMemberS{Value: result.ID},
+			"SongID":  &types.AttributeValueMemberS{Value: result.SongID},
+			"Status":  &types.AttributeValueMemberS{Value: result.Status},
+			"Message": &types.AttributeValueMemberS{Value: result.Message},
+			"Data":    &types.AttributeValueMemberS{Value: result.Data},
+		},
+	}
+
+	_, err := s.Client.PutItem(ctx, input)
+	if err != nil {
+		return fmt.Errorf("error al guardar resultado de operación en DynamoDB: %w", err)
+	}
+	return nil
+}
+
+func (s *OperationStore) GetOperationResult(ctx context.Context, id, songID string) (*model.OperationResult, error) {
+	input := &dynamodb.GetItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: "OPERATION#" + id},
+			"SK": &types.AttributeValueMemberS{Value: songID},
+		},
+	}
+
+	output, err := s.Client.GetItem(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("error al recuperar resultado de operación desde DynamoDB: %w", err)
+	}
+
+	var result model.OperationResult
+	if len(output.Item) == 0 {
+		return nil, fmt.Errorf("resultado de operación no encontrado")
+	}
+
+	if err := attributevalue.UnmarshalMap(output.Item, &result); err != nil {
+		return nil, fmt.Errorf("error al deserializar resultado de operación: %w", err)
+	}
+	return &result, nil
+}
+
+func (s *OperationStore) DeleteOperationResult(ctx context.Context, id, songID string) error {
+	input := &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: "OPERATION#" + id},
+			"SK": &types.AttributeValueMemberS{Value: songID},
+		},
+	}
+	_, err := s.Client.DeleteItem(ctx, input)
+	if err != nil {
+		return fmt.Errorf("error al eliminar resultado de operación desde DynamoDB: %w", err)
+	}
+	return nil
+}

--- a/microservices/audio_processor/tests/integration/metadata_store_integration_test.go
+++ b/microservices/audio_processor/tests/integration/metadata_store_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestIntegrationMetadataStore(t *testing.T) {
@@ -29,18 +28,13 @@ func TestIntegrationMetadataStore(t *testing.T) {
 		require.NoError(t, err)
 
 		metadata := model.Metadata{
-			ID:             "integration-test-id",
-			Title:          "Integration Test Song",
-			URLYouTube:     "https://www.youtube.com/watch?v=example",
-			URLS3:          "https://s3.amazonaws.com/mybucket/integration-test-id",
-			Platform:       "YouTube",
-			DownloadDate:   time.Now().Format(time.RFC3339),
-			Attempts:       1,
-			Failures:       0,
-			ProcessingDate: time.Now().Format(time.RFC3339),
-			Success:        true,
-			Artist:         "Test Artist",
-			Duration:       240,
+			ID:         "integration-test-id",
+			Title:      "Integration Test Song",
+			URLYouTube: "https://www.youtube.com/watch?v=example",
+			URLS3:      "https://s3.amazonaws.com/mybucket/integration-test-id",
+			Platform:   "YouTube",
+			Artist:     "Test Artist",
+			Duration:   240,
 		}
 
 		// act SaveMetadata
@@ -56,9 +50,6 @@ func TestIntegrationMetadataStore(t *testing.T) {
 		assert.Equal(t, metadata.URLYouTube, retrievedMetadata.URLYouTube)
 		assert.Equal(t, metadata.URLS3, retrievedMetadata.URLS3)
 		assert.Equal(t, metadata.Platform, retrievedMetadata.Platform)
-		assert.Equal(t, metadata.DownloadDate, retrievedMetadata.DownloadDate)
-		assert.Equal(t, metadata.Attempts, retrievedMetadata.Attempts)
-		assert.Equal(t, metadata.Failures, retrievedMetadata.Failures)
 		assert.Equal(t, metadata.Artist, retrievedMetadata.Artist)
 		assert.Equal(t, metadata.Duration, retrievedMetadata.Duration)
 

--- a/microservices/audio_processor/tests/integration/operation_store_integration_test.go
+++ b/microservices/audio_processor/tests/integration/operation_store_integration_test.go
@@ -1,0 +1,124 @@
+package integration
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/dynamodbservice"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestIntegrationOperationStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Saltando test de integración en modo corto")
+	}
+
+	tableName := os.Getenv("DYNAMODB_TABLE_NAME_OPERATION")
+	region := os.Getenv("REGION")
+
+	if tableName == "" || region == "" {
+		t.Fatal("DYNAMODB_TABLE_NAME_OPERATION y REGION no fueron seteados para los tests de integracion")
+	}
+
+	store, err := dynamodbservice.NewOperationStore(tableName, region)
+	require.NoError(t, err)
+
+	t.Run("SaveAndRetrieveOperationResult", func(t *testing.T) {
+		// arrange
+		result := createTestOperationResult("integration-test-id-1")
+
+		// act SaveOperationResult
+		err = store.SaveOperationResult(context.Background(), result)
+		require.NoError(t, err)
+
+		// act GetOperationResult
+		retrievedResult, err := store.GetOperationResult(context.Background(), result.ID, result.SongID)
+		require.NoError(t, err)
+
+		// assert
+		assertOperationResultEqual(t, result, *retrievedResult)
+
+		// cleanup
+		err = store.DeleteOperationResult(context.Background(), result.ID, result.SongID)
+		require.NoError(t, err)
+	})
+
+	t.Run("UpdateOperationResult", func(t *testing.T) {
+		// arrange
+		result := createTestOperationResult("integration-test-id-2")
+
+		// act SaveOperationResult
+		err = store.SaveOperationResult(context.Background(), result)
+		require.NoError(t, err)
+
+		// act update operation result
+		result.Status = "completed"
+		result.Message = "Operation completed successfully"
+		result.Data = "Updated data"
+		err = store.SaveOperationResult(context.Background(), result)
+		require.NoError(t, err)
+
+		// act GetOperationResult
+		updatedResult, err := store.GetOperationResult(context.Background(), result.ID, result.SongID)
+		require.NoError(t, err)
+
+		// assert
+		assert.Equal(t, "completed", updatedResult.Status)
+		assert.Equal(t, "Operation completed successfully", updatedResult.Message)
+		assert.Equal(t, "Updated data", updatedResult.Data)
+
+		// cleanup
+		err = store.DeleteOperationResult(context.Background(), result.ID, result.SongID)
+		require.NoError(t, err)
+	})
+
+	t.Run("DeleteOperationResult", func(t *testing.T) {
+		// arrange
+		result := createTestOperationResult("integration-test-id-3")
+
+		// act SaveOperationResult
+		err = store.SaveOperationResult(context.Background(), result)
+		require.NoError(t, err)
+
+		// act DeleteOperationResult
+		err = store.DeleteOperationResult(context.Background(), result.ID, result.SongID)
+		require.NoError(t, err)
+
+		// act Intentar obtener el resultado de la operación eliminada
+		_, err = store.GetOperationResult(context.Background(), result.ID, result.SongID)
+
+		// assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "resultado de operación no encontrado")
+	})
+
+	t.Run("GetNonExistentOperationResult", func(t *testing.T) {
+		// act
+		_, err := store.GetOperationResult(context.Background(), "non-existent-id", "non-existent-song-id")
+
+		// assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "resultado de operación no encontrado")
+	})
+}
+
+func createTestOperationResult(songID string) model.OperationResult {
+	return model.OperationResult{
+		ID:      uuid.New().String(),
+		SongID:  songID,
+		Status:  "in_progress",
+		Message: "Operation is in progress",
+		Data:    "Some initial data",
+	}
+}
+
+func assertOperationResultEqual(t *testing.T, expected, actual model.OperationResult) {
+	assert.Equal(t, expected.ID, actual.ID)
+	assert.Equal(t, expected.SongID, actual.SongID)
+	assert.Equal(t, expected.Status, actual.Status)
+	assert.Equal(t, expected.Message, actual.Message)
+	assert.Equal(t, expected.Data, actual.Data)
+}

--- a/microservices/audio_processor/tests/unit/operation_store_test.go
+++ b/microservices/audio_processor/tests/unit/operation_store_test.go
@@ -1,0 +1,155 @@
+package unit
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/dynamodbservice"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestSaveOperationResult(t *testing.T) {
+	t.Run("Successful save", func(t *testing.T) {
+		mockClient := new(mockDynamoDBAPI)
+		store := dynamodbservice.OperationStore{
+			Client:    mockClient,
+			TableName: "TestOperationStore",
+		}
+
+		result := model.OperationResult{
+			SongID: "test-song-id",
+		}
+
+		mockClient.On("PutItem", mock.Anything, mock.AnythingOfType("*dynamodb.PutItemInput"), mock.Anything).
+			Return(&dynamodb.PutItemOutput{}, nil)
+
+		err := store.SaveOperationResult(context.Background(), result)
+
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("DynamoDB error", func(t *testing.T) {
+		mockClient := new(mockDynamoDBAPI)
+		store := dynamodbservice.OperationStore{
+			Client:    mockClient,
+			TableName: "TestOperationStore",
+		}
+
+		result := model.OperationResult{
+			SongID: "test-song-id",
+		}
+
+		mockClient.On("PutItem", mock.Anything, mock.AnythingOfType("*dynamodb.PutItemInput"), mock.Anything).
+			Return((*dynamodb.PutItemOutput)(nil), errors.New("dynamoDB error"))
+
+		err := store.SaveOperationResult(context.Background(), result)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error al guardar resultado de operación en DynamoDB")
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestGetOperationResult(t *testing.T) {
+	t.Run("Successful retrieval", func(t *testing.T) {
+		mockClient := new(mockDynamoDBAPI)
+		store := dynamodbservice.OperationStore{
+			Client:    mockClient,
+			TableName: "TestOperationStore",
+		}
+
+		expectedResult := &model.OperationResult{
+			SongID: "test-song-id",
+		}
+
+		mockClient.On("GetItem", mock.Anything, mock.AnythingOfType("*dynamodb.GetItemInput"), mock.Anything).
+			Return(&dynamodb.GetItemOutput{
+				Item: map[string]types.AttributeValue{
+					"SongID": &types.AttributeValueMemberS{Value: "test-song-id"},
+				},
+			}, nil)
+
+		result, err := store.GetOperationResult(context.Background(), "test-operation-id", "test-song-id-123")
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+		mockClient.AssertExpectations(t)
+
+	})
+
+	t.Run("Item not found", func(t *testing.T) {
+		mockClient := new(mockDynamoDBAPI)
+		store := dynamodbservice.OperationStore{
+			Client:    mockClient,
+			TableName: "TestOperationStore",
+		}
+
+		mockClient.On("GetItem", mock.Anything, mock.AnythingOfType("*dynamodb.GetItemInput"), mock.Anything).
+			Return(&dynamodb.GetItemOutput{}, nil)
+
+		result, err := store.GetOperationResult(context.Background(), "non-existent-operation-id", "non-existent-song-id-123")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "resultado de operación no encontrado")
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("DynamoDB error", func(t *testing.T) {
+		mockClient := new(mockDynamoDBAPI)
+		store := dynamodbservice.OperationStore{
+			Client:    mockClient,
+			TableName: "TestOperationStore",
+		}
+
+		mockClient.On("GetItem", mock.Anything, mock.AnythingOfType("*dynamodb.GetItemInput"), mock.Anything).
+			Return((*dynamodb.GetItemOutput)(nil), errors.New("dynamoDB error"))
+
+		result, err := store.GetOperationResult(context.Background(), "test-operation-id", "test-song-id-123")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "error al recuperar resultado de operación desde DynamoDB")
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestDeleteOperationResult(t *testing.T) {
+	t.Run("Successful deletion", func(t *testing.T) {
+		mockClient := new(mockDynamoDBAPI)
+		store := &dynamodbservice.OperationStore{
+			Client:    mockClient,
+			TableName: "TestTable",
+		}
+
+		mockClient.On("DeleteItem", mock.Anything, mock.AnythingOfType("*dynamodb.DeleteItemInput"), mock.Anything).
+			Return(&dynamodb.DeleteItemOutput{}, nil)
+
+		err := store.DeleteOperationResult(context.Background(), "test-operation-id", "test-song-id-123")
+
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("DynamoDB error", func(t *testing.T) {
+		mockClient := new(mockDynamoDBAPI)
+		store := &dynamodbservice.OperationStore{
+			Client:    mockClient,
+			TableName: "TestTable",
+		}
+
+		mockClient.On("DeleteItem", mock.Anything, mock.AnythingOfType("*dynamodb.DeleteItemInput"), mock.Anything).
+			Return((*dynamodb.DeleteItemOutput)(nil), errors.New("dynamoDB error"))
+
+		err := store.DeleteOperationResult(context.Background(), "test-operation-id", "test-song-id-123")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error al eliminar resultado de operación desde DynamoDB")
+		mockClient.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
Se implementó el tipo `OperationStore` para manejar operaciones CRUD (Crear, Leer, Actualizar, Eliminar) relacionadas con los resultados de operación en DynamoDB. La implementación incluye los siguientes cambios:

- **OperationStore**: Nueva estructura que gestiona el almacenamiento, recuperación y eliminación de resultados de operación en DynamoDB.
- **Métodos**:
  - `SaveOperationResult`: Guarda el resultado de una operación en DynamoDB, generando un nuevo ID si es necesario.
  - `GetOperationResult`: Recupera el resultado de una operación desde DynamoDB usando el ID y el SongID proporcionados.
  - `DeleteOperationResult`: Elimina el resultado de una operación de DynamoDB usando el ID y el SongID proporcionados.

Además, se añadieron pruebas unitarias e integraciones para asegurar el correcto funcionamiento de `OperationStore`:

- **Pruebas Unitarias**: Validan el comportamiento de los métodos `SaveOperationResult`, `GetOperationResult` y `DeleteOperationResult`, cubriendo casos de éxito y manejo de errores.
- **Pruebas de Integración**: Aseguran que `OperationStore` interactúa correctamente con DynamoDB, validando las operaciones de almacenamiento, recuperación y eliminación de resultados de operación.