### PR TITLE
Add repository interfaces for Metadata and Operation

### DIFF
--- a/microservices/audio_processor/internal/domain/model/metadata.go
+++ b/microservices/audio_processor/internal/domain/model/metadata.go
@@ -7,13 +7,12 @@ type Metadata struct {
 	// Este campo se utiliza para asociar la metadata con una canción específica.
 	ID string `json:"id"`
 
+	// VideoID Es el identificador del video
+	VideoID string `json:"video_id"`
+
 	// Title es el título de la canción.
 	// Representa el nombre de la canción tal como aparece en la fuente de origen.
 	Title string `json:"title"`
-
-	// Artist es el nombre del artista o grupo que interpreta la canción.
-	// Este campo ayuda a identificar el creador de la música.
-	Artist string `json:"artist"`
 
 	// Duration es la duración de la canción en segundos.
 	// Representa cuánto tiempo dura la canción desde el inicio hasta el final.

--- a/microservices/audio_processor/internal/domain/repository/metadata_repository.go
+++ b/microservices/audio_processor/internal/domain/repository/metadata_repository.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+)
+
+// MetadataRepository define las operaciones para manejar metadatos.
+type MetadataRepository interface {
+	SaveMetadata(ctx context.Context, metadata model.Metadata) error
+	GetMetadata(ctx context.Context, id string) (*model.Metadata, error)
+	DeleteMetadata(ctx context.Context, id string) error
+}

--- a/microservices/audio_processor/internal/domain/repository/operation_repository.go
+++ b/microservices/audio_processor/internal/domain/repository/operation_repository.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+)
+
+// OperationRepository define las operaciones para manejar resultados de operación.
+type OperationRepository interface {
+	SaveOperationsResult(ctx context.Context, result model.OperationResult) error
+	GetOperationResult(ctx context.Context, id, songID string) (*model.OperationResult, error)
+	DeleteOperationResult(ctx context.Context, id, songID string) error
+}

--- a/microservices/audio_processor/internal/infrastructure/encoder/encoder.go
+++ b/microservices/audio_processor/internal/infrastructure/encoder/encoder.go
@@ -328,7 +328,7 @@ func (e *EncodeSession) handleStderrLine(line string) {
 	// Analiza la línea y extrae el tamaño, tiempo, tasa de bits y velocidad.
 	_, err := fmt.Sscanf(line, "size=%dkB time=%d:%d:%f bitrate=%fkbits/s speed=%fx", &size, &timeH, &timeM, &timeS, &bitrate, &speed)
 	if err != nil {
-		e.logging.Error("Error al analizar línea de stderr", zap.Error(err)) // Registra un error si el análisis falla.
+		//e.logging.Error("Error al analizar línea de stderr", zap.Error(err)) // Registra un error si el análisis falla.
 	}
 
 	// Calcula la duración total en base a las horas, minutos y segundos extraídos.

--- a/microservices/audio_processor/internal/infrastructure/persistence/dynamodb/metadata_store.go
+++ b/microservices/audio_processor/internal/infrastructure/persistence/dynamodb/metadata_store.go
@@ -1,4 +1,4 @@
-package dynamodbservice
+package dynamodb
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 )
 
 type (
-	// MetadataStore proporciona operaciones para almacenar, recuperar y eliminar metadatos en DynamoDB.
+	// MetadataStore Implementa la interface repository.MetadataRepository proporciona operaciones para almacenar, recuperar y eliminar metadatos en DynamoDB.
 	MetadataStore struct {
 		Client    DynamoDBAPI // Cliente para interactuar con DynamoDB.
 		TableName string      // Nombre de la tabla en DynamoDB.
@@ -61,7 +61,6 @@ func (s *MetadataStore) SaveMetadata(ctx context.Context, metadata model.Metadat
 			"Thumbnail":  &types.AttributeValueMemberS{Value: metadata.Thumbnail},
 			"URLS3":      &types.AttributeValueMemberS{Value: metadata.URLS3},
 			"Platform":   &types.AttributeValueMemberS{Value: metadata.Platform},
-			"Artist":     &types.AttributeValueMemberS{Value: metadata.Artist},
 			"Duration":   &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", metadata.Duration)},
 		},
 	})

--- a/microservices/audio_processor/internal/infrastructure/persistence/dynamodb/operation_store.go
+++ b/microservices/audio_processor/internal/infrastructure/persistence/dynamodb/operation_store.go
@@ -1,4 +1,4 @@
-package dynamodbservice
+package dynamodb
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// OperationStore maneja el almacenamiento, recuperación y eliminación de resultados de operación en DynamoDB.
+// OperationStore implementa la interface repository.OperationRepository maneja el almacenamiento, recuperación y eliminación de resultados de operación en DynamoDB.
 type OperationStore struct {
 	Client    DynamoDBAPI // Cliente para interactuar con DynamoDB.
 	TableName string      // Nombre de la tabla en DynamoDB.
@@ -35,8 +35,8 @@ func NewOperationStore(tableName string, region string) (*OperationStore, error)
 	}, nil
 }
 
-// SaveOperationResult guarda el resultado de una operación en DynamoDB. Genera un nuevo ID si es necesario.
-func (s *OperationStore) SaveOperationResult(ctx context.Context, result model.OperationResult) error {
+// SaveOperationsResult guarda el resultado de una operación en DynamoDB. Genera un nuevo ID si es necesario.
+func (s *OperationStore) SaveOperationsResult(ctx context.Context, result model.OperationResult) error {
 	if result.ID == "" {
 		result.ID = uuid.New().String() // Genera un nuevo ID si es necesario.
 	}

--- a/microservices/audio_processor/tests/integration/metadata_store_integration_test.go
+++ b/microservices/audio_processor/tests/integration/metadata_store_integration_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/dynamodbservice"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/persistence/dynamodb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -24,7 +24,7 @@ func TestIntegrationMetadataStore(t *testing.T) {
 
 	t.Run("SaveAndRetrieveMetadata", func(t *testing.T) {
 		// arrange
-		store, err := dynamodbservice.NewMetadataStore(tableName, region)
+		store, err := dynamodb.NewMetadataStore(tableName, region)
 		require.NoError(t, err)
 
 		metadata := model.Metadata{
@@ -33,7 +33,6 @@ func TestIntegrationMetadataStore(t *testing.T) {
 			URLYouTube: "https://www.youtube.com/watch?v=example",
 			URLS3:      "https://s3.amazonaws.com/mybucket/integration-test-id",
 			Platform:   "YouTube",
-			Artist:     "Test Artist",
 			Duration:   240,
 		}
 
@@ -50,7 +49,6 @@ func TestIntegrationMetadataStore(t *testing.T) {
 		assert.Equal(t, metadata.URLYouTube, retrievedMetadata.URLYouTube)
 		assert.Equal(t, metadata.URLS3, retrievedMetadata.URLS3)
 		assert.Equal(t, metadata.Platform, retrievedMetadata.Platform)
-		assert.Equal(t, metadata.Artist, retrievedMetadata.Artist)
 		assert.Equal(t, metadata.Duration, retrievedMetadata.Duration)
 
 		// act - delete metadata

--- a/microservices/audio_processor/tests/integration/operation_store_integration_test.go
+++ b/microservices/audio_processor/tests/integration/operation_store_integration_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/dynamodbservice"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/persistence/dynamodb"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +23,7 @@ func TestIntegrationOperationStore(t *testing.T) {
 		t.Fatal("DYNAMODB_TABLE_NAME_OPERATION y REGION no fueron seteados para los tests de integracion")
 	}
 
-	store, err := dynamodbservice.NewOperationStore(tableName, region)
+	store, err := dynamodb.NewOperationStore(tableName, region)
 	require.NoError(t, err)
 
 	t.Run("SaveAndRetrieveOperationResult", func(t *testing.T) {
@@ -31,7 +31,7 @@ func TestIntegrationOperationStore(t *testing.T) {
 		result := createTestOperationResult("integration-test-id-1")
 
 		// act SaveOperationResult
-		err = store.SaveOperationResult(context.Background(), result)
+		err = store.SaveOperationsResult(context.Background(), result)
 		require.NoError(t, err)
 
 		// act GetOperationResult
@@ -51,14 +51,14 @@ func TestIntegrationOperationStore(t *testing.T) {
 		result := createTestOperationResult("integration-test-id-2")
 
 		// act SaveOperationResult
-		err = store.SaveOperationResult(context.Background(), result)
+		err = store.SaveOperationsResult(context.Background(), result)
 		require.NoError(t, err)
 
 		// act update operation result
 		result.Status = "completed"
 		result.Message = "Operation completed successfully"
 		result.Data = "Updated data"
-		err = store.SaveOperationResult(context.Background(), result)
+		err = store.SaveOperationsResult(context.Background(), result)
 		require.NoError(t, err)
 
 		// act GetOperationResult
@@ -80,7 +80,7 @@ func TestIntegrationOperationStore(t *testing.T) {
 		result := createTestOperationResult("integration-test-id-3")
 
 		// act SaveOperationResult
-		err = store.SaveOperationResult(context.Background(), result)
+		err = store.SaveOperationsResult(context.Background(), result)
 		require.NoError(t, err)
 
 		// act DeleteOperationResult

--- a/microservices/audio_processor/tests/unit/metadata_store_test.go
+++ b/microservices/audio_processor/tests/unit/metadata_store_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/dynamodbservice"
+	dynamodb2 "github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/persistence/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/stretchr/testify/assert"
@@ -36,14 +36,13 @@ func TestMetadataStore(t *testing.T) {
 		t.Run("Successful save", func(t *testing.T) {
 			// arrange
 			mockClient := new(mockDynamoDBAPI)
-			store := dynamodbservice.MetadataStore{
+			store := dynamodb2.MetadataStore{
 				Client:    mockClient,
 				TableName: "test-table",
 			}
 			metadata := model.Metadata{
 				ID:       "test-id",
 				Title:    "Test Song",
-				Artist:   "Test Artist",
 				Duration: 180,
 			}
 			mockClient.On("PutItem", mock.Anything, mock.AnythingOfType("*dynamodb.PutItemInput"), mock.Anything).Return(&dynamodb.PutItemOutput{}, nil)
@@ -60,14 +59,13 @@ func TestMetadataStore(t *testing.T) {
 	t.Run("DynamoDB error", func(t *testing.T) {
 		// arrange
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.MetadataStore{
+		store := &dynamodb2.MetadataStore{
 			Client:    mockClient,
 			TableName: "test-table",
 		}
 		metadata := model.Metadata{
 			ID:       "test-id",
 			Title:    "Test Song",
-			Artist:   "Test Artist",
 			Duration: 180,
 		}
 		mockClient.On("PutItem", mock.Anything, mock.AnythingOfType("*dynamodb.PutItemInput"), mock.Anything).Return(&dynamodb.PutItemOutput{}, errors.New("DynamoDB error"))
@@ -88,7 +86,7 @@ func TestMetadataStore(t *testing.T) {
 			region := "us-east-1"
 
 			// act
-			store, err := dynamodbservice.NewMetadataStore(tableName, region)
+			store, err := dynamodb2.NewMetadataStore(tableName, region)
 
 			// assert
 			assert.NoError(t, err)
@@ -100,7 +98,7 @@ func TestMetadataStore(t *testing.T) {
 
 	t.Run("Successful retrieval", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.MetadataStore{
+		store := &dynamodb2.MetadataStore{
 			Client:    mockClient,
 			TableName: "TestTable",
 		}
@@ -121,7 +119,7 @@ func TestMetadataStore(t *testing.T) {
 
 	t.Run("Item not found", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.MetadataStore{
+		store := &dynamodb2.MetadataStore{
 			Client:    mockClient,
 			TableName: "TestTable",
 		}
@@ -136,7 +134,7 @@ func TestMetadataStore(t *testing.T) {
 
 	t.Run("DynamoDB error", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.MetadataStore{
+		store := &dynamodb2.MetadataStore{
 			Client:    mockClient,
 			TableName: "TestTable",
 		}
@@ -156,7 +154,7 @@ func TestMetadataStore(t *testing.T) {
 func TestGetMetadata(t *testing.T) {
 	t.Run("Successful deletion", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.MetadataStore{
+		store := &dynamodb2.MetadataStore{
 			Client:    mockClient,
 			TableName: "TestTable",
 		}
@@ -170,7 +168,7 @@ func TestGetMetadata(t *testing.T) {
 
 	t.Run("DynamoDB error", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.MetadataStore{
+		store := &dynamodb2.MetadataStore{
 			Client:    mockClient,
 			TableName: "TestTable",
 		}

--- a/microservices/audio_processor/tests/unit/operation_store_test.go
+++ b/microservices/audio_processor/tests/unit/operation_store_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/dynamodbservice"
+	dynamodb2 "github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/persistence/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +15,7 @@ import (
 func TestSaveOperationResult(t *testing.T) {
 	t.Run("Successful save", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := dynamodbservice.OperationStore{
+		store := dynamodb2.OperationStore{
 			Client:    mockClient,
 			TableName: "TestOperationStore",
 		}
@@ -27,7 +27,7 @@ func TestSaveOperationResult(t *testing.T) {
 		mockClient.On("PutItem", mock.Anything, mock.AnythingOfType("*dynamodb.PutItemInput"), mock.Anything).
 			Return(&dynamodb.PutItemOutput{}, nil)
 
-		err := store.SaveOperationResult(context.Background(), result)
+		err := store.SaveOperationsResult(context.Background(), result)
 
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
@@ -35,7 +35,7 @@ func TestSaveOperationResult(t *testing.T) {
 
 	t.Run("DynamoDB error", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := dynamodbservice.OperationStore{
+		store := dynamodb2.OperationStore{
 			Client:    mockClient,
 			TableName: "TestOperationStore",
 		}
@@ -47,7 +47,7 @@ func TestSaveOperationResult(t *testing.T) {
 		mockClient.On("PutItem", mock.Anything, mock.AnythingOfType("*dynamodb.PutItemInput"), mock.Anything).
 			Return((*dynamodb.PutItemOutput)(nil), errors.New("dynamoDB error"))
 
-		err := store.SaveOperationResult(context.Background(), result)
+		err := store.SaveOperationsResult(context.Background(), result)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "error al guardar resultado de operación en DynamoDB")
@@ -58,7 +58,7 @@ func TestSaveOperationResult(t *testing.T) {
 func TestGetOperationResult(t *testing.T) {
 	t.Run("Successful retrieval", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := dynamodbservice.OperationStore{
+		store := dynamodb2.OperationStore{
 			Client:    mockClient,
 			TableName: "TestOperationStore",
 		}
@@ -84,7 +84,7 @@ func TestGetOperationResult(t *testing.T) {
 
 	t.Run("Item not found", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := dynamodbservice.OperationStore{
+		store := dynamodb2.OperationStore{
 			Client:    mockClient,
 			TableName: "TestOperationStore",
 		}
@@ -102,7 +102,7 @@ func TestGetOperationResult(t *testing.T) {
 
 	t.Run("DynamoDB error", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := dynamodbservice.OperationStore{
+		store := dynamodb2.OperationStore{
 			Client:    mockClient,
 			TableName: "TestOperationStore",
 		}
@@ -122,7 +122,7 @@ func TestGetOperationResult(t *testing.T) {
 func TestDeleteOperationResult(t *testing.T) {
 	t.Run("Successful deletion", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.OperationStore{
+		store := &dynamodb2.OperationStore{
 			Client:    mockClient,
 			TableName: "TestTable",
 		}
@@ -138,7 +138,7 @@ func TestDeleteOperationResult(t *testing.T) {
 
 	t.Run("DynamoDB error", func(t *testing.T) {
 		mockClient := new(mockDynamoDBAPI)
-		store := &dynamodbservice.OperationStore{
+		store := &dynamodb2.OperationStore{
 			Client:    mockClient,
 			TableName: "TestTable",
 		}


### PR DESCRIPTION
Este PR introduce interfaces para el manejo de metadatos y resultados de operación en el paquete repository. Esto mejora la separación de preocupaciones y permite una mayor flexibilidad en las pruebas y la implementación de la lógica de negocio.
