### PR TITLE
Implement audio download use case with tests

### DIFF
--- a/microservices/audio_processor/go.mod
+++ b/microservices/audio_processor/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.61.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
 	mccoy.space/g/ogg v0.0.0-20221103053400-1ea94e6f3152

--- a/microservices/audio_processor/go.sum
+++ b/microservices/audio_processor/go.sum
@@ -74,8 +74,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/microservices/audio_processor/internal/domain/service/audio_processing_service.go
+++ b/microservices/audio_processor/internal/domain/service/audio_processing_service.go
@@ -30,14 +30,21 @@ const (
 )
 
 // AudioProcessingService es un servicio que maneja la descarga, codificación y almacenamiento de audio.
-type AudioProcessingService struct {
-	log            logger.Logger                  // Logger para el registro de eventos y errores.
-	storage        storage.Storage                // Interfaz para el almacenamiento en S3.
-	downloader     downloader.Downloader          // Interfaz para la descarga de audio.
-	operationStore repository.OperationRepository // Interfaz para almacenar resultados de operaciones.
-	metadataStore  repository.MetadataRepository  // Interfaz para almacenar metadatos del audio.
-	config         config.Config                  // Configuración del servicio.
-}
+type (
+	AudioProcessingService struct {
+		log            logger.Logger                  // Logger para el registro de eventos y errores.
+		storage        storage.Storage                // Interfaz para el almacenamiento en S3.
+		downloader     downloader.Downloader          // Interfaz para la descarga de audio.
+		operationStore repository.OperationRepository // Interfaz para almacenar resultados de operaciones.
+		metadataStore  repository.MetadataRepository  // Interfaz para almacenar metadatos del audio.
+		config         config.Config                  // Configuración del servicio.
+	}
+
+	AudioProcessor interface {
+		StartOperation(ctx context.Context, song string) (string, error)
+		ProcessAudio(ctx context.Context, operationID string, metadata api.VideoDetails) error
+	}
+)
 
 // NewAudioProcessingService crea una nueva instancia de AudioProcessingService con las configuraciones proporcionadas.
 func NewAudioProcessingService(log logger.Logger, storage storage.Storage,

--- a/microservices/audio_processor/internal/usecase/initiate_download.go
+++ b/microservices/audio_processor/internal/usecase/initiate_download.go
@@ -1,0 +1,50 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/service"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/api"
+	"sync"
+)
+
+type InitiateDownloadUseCase struct {
+	audioService service.AudioProcessor
+	youtubeAPI   api.YouTubeService
+}
+
+func NewInitiateDownloadUseCase(audioService service.AudioProcessor, youtubeAPI api.YouTubeService) *InitiateDownloadUseCase {
+	return &InitiateDownloadUseCase{
+		audioService: audioService,
+		youtubeAPI:   youtubeAPI,
+	}
+}
+
+func (uc *InitiateDownloadUseCase) Execute(ctx context.Context, song string) (string, error) {
+	var wg sync.WaitGroup
+	videoID, err := uc.youtubeAPI.SearchVideoID(ctx, song)
+	if err != nil {
+		return "", fmt.Errorf("error al buscar el ID de la cancion: %w", err)
+	}
+
+	youtubeMetadata, err := uc.youtubeAPI.GetVideoDetails(ctx, videoID)
+	if err != nil {
+		return "", fmt.Errorf("error al obtener metadata de YouTube: %w", err)
+	}
+
+	operationID, err := uc.audioService.StartOperation(ctx, videoID)
+	if err != nil {
+		return "", fmt.Errorf("error al iniciar la operación: %w", err)
+	}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		err := uc.audioService.ProcessAudio(ctx, operationID, *youtubeMetadata)
+		if err != nil {
+			fmt.Printf("Error en el procesamiento: %v", err)
+		}
+	}()
+	wg.Wait()
+	return operationID, nil
+}

--- a/microservices/audio_processor/tests/unit/initiate_download_test.go
+++ b/microservices/audio_processor/tests/unit/initiate_download_test.go
@@ -1,0 +1,133 @@
+package unit
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/api"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestInitiateDownloadUseCase_Execute(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Arrange
+		mockYouTubeService := new(MockYouTubeService)
+		mockAudioService := new(MockAudioProcessingService)
+
+		uc := usecase.NewInitiateDownloadUseCase(mockAudioService, mockYouTubeService)
+
+		ctx := context.Background()
+		song := "test song"
+
+		// Setup expectativas
+		videoID := "test-video-id"
+		youtubeMetadata := &api.VideoDetails{
+			VideoID:    videoID,
+			Title:      "Test Video",
+			Duration:   "3:00",
+			URLYouTube: "https://youtube.com/watch?v=test-video-id",
+		}
+
+		mockYouTubeService.On("SearchVideoID", ctx, song).Return(videoID, nil)
+		mockYouTubeService.On("GetVideoDetails", ctx, videoID).Return(youtubeMetadata, nil)
+		mockAudioService.On("StartOperation", ctx, videoID).Return("test-operation-id", nil)
+		mockAudioService.On("ProcessAudio", ctx, "test-operation-id", *youtubeMetadata).Return(nil)
+
+		// Act
+		operationID, err := uc.Execute(ctx, song)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, "test-operation-id", operationID)
+
+		mockYouTubeService.AssertExpectations(t)
+		mockAudioService.AssertExpectations(t)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		mockYouTubeService := new(MockYouTubeService)
+		mockAudioService := new(MockAudioProcessingService)
+
+		uc := usecase.NewInitiateDownloadUseCase(mockAudioService, mockYouTubeService)
+
+		ctx := context.Background()
+		song := "test song"
+		videoID := "test-video-id"
+		operationID := "test-operation-id"
+		youtubeMetadata := &api.VideoDetails{
+			VideoID:    "test-video-id",
+			Title:      "Test Video",
+			Duration:   "3:00",
+			URLYouTube: "https://youtube.com/watch?v=test-video-id",
+			Thumbnail:  "https://img.youtube.com/vi/test-video-id/0.jpg",
+		}
+		expectedError := errors.New("error procesando audio")
+
+		mockYouTubeService.On("SearchVideoID", ctx, song).Return(videoID, nil)
+		mockYouTubeService.On("GetVideoDetails", ctx, videoID).Return(youtubeMetadata, nil)
+		mockAudioService.On("StartOperation", ctx, videoID).Return(operationID, nil)
+		mockAudioService.On("ProcessAudio", ctx, operationID, *youtubeMetadata).Return(expectedError)
+
+		// act
+		operationIDResult, err := uc.Execute(ctx, song)
+
+		// assert
+		assert.NoError(t, err)
+		assert.Equal(t, operationID, operationIDResult)
+		mockYouTubeService.AssertExpectations(t)
+	})
+
+	t.Run("Error in the search ID of the song", func(t *testing.T) {
+		ctx := context.Background()
+		song := "test song"
+
+		mockYouTube := new(MockYouTubeService)
+		mockAudioService := new(MockAudioProcessingService)
+
+		uc := usecase.NewInitiateDownloadUseCase(mockAudioService, mockYouTube)
+
+		mockYouTube.On("SearchVideoID", ctx, song).Return("", errors.New("error al buscar ID"))
+
+		_, err := uc.Execute(ctx, song)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error al buscar el ID de la cancion")
+	})
+
+	t.Run("Error getting YouTube metadata", func(t *testing.T) {
+		ctx := context.Background()
+		song := "test song"
+		mockYouTube := new(MockYouTubeService)
+		mockAudioService := new(MockAudioProcessingService)
+
+		uc := usecase.NewInitiateDownloadUseCase(mockAudioService, mockYouTube)
+
+		videoID := "test-video-id"
+		mockYouTube.On("SearchVideoID", ctx, song).Return(videoID, nil)
+		mockYouTube.On("GetVideoDetails", ctx, videoID).Return(&api.VideoDetails{}, errors.New("error al obtener metadata"))
+
+		_, err := uc.Execute(ctx, song)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error al obtener metadata de YouTube")
+	})
+
+	t.Run("Error starting operation", func(t *testing.T) {
+		song := "test song"
+		ctx := context.Background()
+
+		mockYouTube := new(MockYouTubeService)
+		mockAudioService := new(MockAudioProcessingService)
+
+		uc := usecase.NewInitiateDownloadUseCase(mockAudioService, mockYouTube)
+
+		videoID := "test-video-id"
+		mockYouTube.On("SearchVideoID", ctx, song).Return(videoID, nil)
+		mockYouTube.On("GetVideoDetails", ctx, videoID).Return(&api.VideoDetails{}, nil)
+		mockAudioService.On("StartOperation", ctx, videoID).Return("", errors.New("error al iniciar operación"))
+
+		_, err := uc.Execute(ctx, song)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error al iniciar la operación")
+	})
+}

--- a/microservices/audio_processor/tests/unit/mocks.go
+++ b/microservices/audio_processor/tests/unit/mocks.go
@@ -3,6 +3,7 @@ package unit
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/api"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap/zapcore"
 	"io"
@@ -26,6 +27,14 @@ type (
 	}
 
 	MockLogger struct {
+		mock.Mock
+	}
+
+	MockYouTubeService struct {
+		mock.Mock
+	}
+
+	MockAudioProcessingService struct {
 		mock.Mock
 	}
 )
@@ -93,4 +102,24 @@ func (m *MockLogger) Debug(msg string, fields ...zapcore.Field) {
 
 func (m *MockLogger) With(fields ...zapcore.Field) {
 	m.Called(fields)
+}
+
+func (m *MockYouTubeService) SearchVideoID(ctx context.Context, song string) (string, error) {
+	args := m.Called(ctx, song)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockYouTubeService) GetVideoDetails(ctx context.Context, videoID string) (*api.VideoDetails, error) {
+	args := m.Called(ctx, videoID)
+	return args.Get(0).(*api.VideoDetails), args.Error(1)
+}
+
+func (m *MockAudioProcessingService) StartOperation(ctx context.Context, videoID string) (string, error) {
+	args := m.Called(ctx, videoID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockAudioProcessingService) ProcessAudio(ctx context.Context, operationID string, videoDetails api.VideoDetails) error {
+	args := m.Called(ctx, operationID, videoDetails)
+	return args.Error(0)
 }


### PR DESCRIPTION
### Descripción
Este pull request agrega la implementación del caso de uso `InitiateDownloadUseCase` y pruebas unitarias para cubrir los siguientes escenarios de error:

- **Error en la búsqueda del ID de la canción**: Se simula un error al intentar buscar el ID de la canción, garantizando que se maneje correctamente y se devuelva un mensaje de error apropiado.
  
- **Error al obtener metadata de YouTube**: Se simula un error al obtener los detalles del video después de haber encontrado el ID, asegurando que el flujo de control se mantenga y se devuelva un error significativo.
  
- **Error al iniciar la operación**: Se simula un error al intentar iniciar la operación, verificando que el error se maneje correctamente y se notifique al usuario.

### Cambios Realizados
- Se implementó el caso de uso `InitiateDownloadUseCase` para gestionar la descarga y procesamiento de audio desde YouTube.
- Se crearon mocks para `YouTubeService` y `AudioProcessingService` para simular comportamientos en los tests.
- Se implementaron pruebas específicas para cubrir las condiciones de error mencionadas.
