### PR TITLE
Fix code scanning alert no. 1: Missing regular expression anchor

### DIFF
--- a/microservices/audio_processor/internal/infrastructure/api/youtube.go
+++ b/microservices/audio_processor/internal/infrastructure/api/youtube.go
@@ -167,7 +167,7 @@ func (c *YouTubeClient) SearchVideoID(ctx context.Context, input string) (string
 // ExtractVideoIDFromURL extrae el ID del video de una URL de YouTube.
 func ExtractVideoIDFromURL(videoURL string) (string, error) {
 	// Expresión regular para extraer el ID del video de una URL de YouTube
-	re := regexp.MustCompile(`(?:https?://)?(?:www\.)?youtube\.com/(?:watch\?v=|embed/|v/|.+/v/|.+/embed/|user/(?:\w+/)?\w+/\w+/|watch\?.*v=|shorts/|playlist\?list=)([\w-]{11})`)
+	re := regexp.MustCompile(`^(?:https?://)?(?:www\.)?youtube\.com/(?:watch\?v=|embed/|v/|.+/v/|.+/embed/|user/(?:\w+/)?\w+/\w+/|watch\?.*v=|shorts/|playlist\?list=)([\w-]{11})$`)
 	matches := re.FindStringSubmatch(videoURL)
 	if len(matches) > 1 {
 		return matches[1], nil


### PR DESCRIPTION
Fixes [https://github.com/Tomas-vilte/ButakeroMusicBotGo/security/code-scanning/1](https://github.com/Tomas-vilte/ButakeroMusicBotGo/security/code-scanning/1)

To fix the problem, we need to add anchors to the regular expression used in the `ExtractVideoIDFromURL` function. This will ensure that the regular expression matches the entire input string, rather than any substring within it. Specifically, we will add the `^` anchor at the beginning and the `$` anchor at the end of the regular expression.

- **General Fix:** Add `^` at the beginning and `$` at the end of the regular expression to ensure it matches the entire input string.
- **Detailed Fix:** Modify the regular expression on line 170 in the file `microservices/audio_processor/internal/infrastructure/api/youtube.go` to include the anchors.
- **Specific Changes:** Update the regular expression pattern to `^(?:https?://)?(?:www\.)?youtube\.com/(?:watch\?v=|embed/|v/|.+/v/|.+/embed/|user/(?:\w+/)?\w+/\w+/|watch\?.*v=|shorts/|playlist\?list=)([\w-]{11})$`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
