### PR TITLE
Implement AudioHandler for managing audio download initiation and status retrieval with tests

### DIFF
--- a/microservices/audio_processor/cmd/main.go
+++ b/microservices/audio_processor/cmd/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/cmd/server"
+	"log"
+)
+
+func main() {
+	if err := server.StartServer(); err != nil {
+		log.Fatalf("Error al iniciar server: %v", err)
+	}
+}

--- a/microservices/audio_processor/cmd/server/server.go
+++ b/microservices/audio_processor/cmd/server/server.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/config"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/service"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/api"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/downloader"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/persistence/dynamodb"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/storage"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/interface/http/handler"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/interface/router"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/usecase"
+	"github.com/gin-gonic/gin"
+	"os"
+	"time"
+)
+
+func StartServer() error {
+	cfg := config.Config{
+		MaxAttempts:           3,
+		Timeout:               4 * time.Minute,
+		BucketName:            os.Getenv("BUCKET_NAME"),
+		Region:                os.Getenv("REGION"),
+		YouTubeApiKey:         os.Getenv("YOUTUBE_API_KEY"),
+		SongsTable:            os.Getenv("DYNAMODB_TABLE_NAME_SONGS"),
+		OperationResultsTable: os.Getenv("DYNAMODB_TABLE_NAME_OPERATION"),
+	}
+
+	log, err := logger.NewZapLogger()
+	if err != nil {
+		return err
+	}
+	defer log.Close()
+
+	storageService, err := storage.NewS3Storage(cfg.BucketName, cfg.Region)
+	if err != nil {
+		return err
+	}
+
+	downloaderMusic := downloader.NewYTDLPDownloader(log, downloader.YTDLPOptions{UseOAuth2: false})
+	operationRepo, err := dynamodb.NewOperationStore(cfg.OperationResultsTable, cfg.Region)
+	if err != nil {
+		return err
+	}
+
+	metadataRepo, err := dynamodb.NewMetadataStore(cfg.SongsTable, cfg.Region)
+	if err != nil {
+		return err
+	}
+
+	youtubeAPI := api.NewYouTubeClient(cfg.YouTubeApiKey)
+	audioProcessingService := service.NewAudioProcessingService(
+		log,
+		storageService,
+		downloaderMusic,
+		operationRepo,
+		metadataRepo,
+		cfg,
+	)
+	getOperationStatus := usecase.NewGetOperationStatusUseCase(operationRepo)
+	initiateDownloadUC := usecase.NewInitiateDownloadUseCase(audioProcessingService, youtubeAPI)
+	audioHandler := handler.NewAudioHandler(initiateDownloadUC, getOperationStatus)
+	r := gin.Default()
+	router.SetupRoutes(r, audioHandler)
+
+	return r.Run(":8080")
+}

--- a/microservices/audio_processor/internal/config/config.go
+++ b/microservices/audio_processor/internal/config/config.go
@@ -3,6 +3,11 @@ package config
 import "time"
 
 type Config struct {
-	MaxAttempts int
-	Timeout     time.Duration
+	MaxAttempts           int
+	Timeout               time.Duration
+	BucketName            string
+	Region                string
+	OperationResultsTable string
+	SongsTable            string
+	YouTubeApiKey         string
 }

--- a/microservices/audio_processor/internal/interface/http/handler/audio_handler.go
+++ b/microservices/audio_processor/internal/interface/http/handler/audio_handler.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/usecase"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type AudioHandler struct {
+	initiateDownloadUC   usecase.InitialDownloadUseCase
+	getOperationStatusUC usecase.GetOperationStatusUseCase
+}
+
+func NewAudioHandler(initiateDownloadUC usecase.InitialDownloadUseCase, getOperationStatusUC usecase.GetOperationStatusUseCase) *AudioHandler {
+	return &AudioHandler{
+		initiateDownloadUC:   initiateDownloadUC,
+		getOperationStatusUC: getOperationStatusUC,
+	}
+}
+
+func (h *AudioHandler) InitiateDownload(c *gin.Context) {
+	song := c.Query("song")
+	if song == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Falta el parametro 'song'",
+		})
+		return
+	}
+
+	operationID, err := h.initiateDownloadUC.Execute(context.Background(), song)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"operation_id": operationID})
+}
+
+func (h *AudioHandler) GetOperationStatus(c *gin.Context) {
+	operationID := c.Query("operation_id")
+	songID := c.Query("song_id")
+
+	if operationID == "" || songID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Faltan los parámetros 'operationID' y/o 'songID'",
+		})
+		return
+	}
+	status, err := h.getOperationStatusUC.Execute(context.Background(), operationID, songID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": status})
+}

--- a/microservices/audio_processor/internal/interface/http/handler/audio_handler.go
+++ b/microservices/audio_processor/internal/interface/http/handler/audio_handler.go
@@ -28,7 +28,7 @@ func (h *AudioHandler) InitiateDownload(c *gin.Context) {
 		return
 	}
 
-	operationID, err := h.initiateDownloadUC.Execute(context.Background(), song)
+	operationID, err := h.initiateDownloadUC.Execute(c.Request.Context(), song)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/microservices/audio_processor/internal/interface/router/routes.go
+++ b/microservices/audio_processor/internal/interface/router/routes.go
@@ -1,0 +1,14 @@
+package router
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/interface/http/handler"
+	"github.com/gin-gonic/gin"
+)
+
+func SetupRoutes(router *gin.Engine, audioHandler *handler.AudioHandler) {
+	api := router.Group("/api")
+	{
+		api.POST("/audio/start", audioHandler.InitiateDownload)
+		api.GET("/audio/status", audioHandler.GetOperationStatus)
+	}
+}

--- a/microservices/audio_processor/internal/usecase/get_operation_status.go
+++ b/microservices/audio_processor/internal/usecase/get_operation_status.go
@@ -7,17 +7,17 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/repository"
 )
 
-type GetOperationStatusUseCase struct {
+type GetOperationStatusUseCaseImpl struct {
 	operationRepository repository.OperationRepository
 }
 
-func NewGetOperationStatusUseCase(operationRepository repository.OperationRepository) *GetOperationStatusUseCase {
-	return &GetOperationStatusUseCase{
+func NewGetOperationStatusUseCase(operationRepository repository.OperationRepository) *GetOperationStatusUseCaseImpl {
+	return &GetOperationStatusUseCaseImpl{
 		operationRepository: operationRepository,
 	}
 }
 
-func (uc *GetOperationStatusUseCase) Execute(ctx context.Context, operationID, songID string) (model.OperationResult, error) {
+func (uc *GetOperationStatusUseCaseImpl) Execute(ctx context.Context, operationID, songID string) (model.OperationResult, error) {
 	operation, err := uc.operationRepository.GetOperationResult(ctx, operationID, songID)
 	if err != nil {
 		return model.OperationResult{}, fmt.Errorf("error al obtener la operación: %w", err)

--- a/microservices/audio_processor/internal/usecase/interfaces.go
+++ b/microservices/audio_processor/internal/usecase/interfaces.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+)
+
+type (
+	InitialDownloadUseCase interface {
+		Execute(ctx context.Context, song string) (string, error)
+	}
+
+	GetOperationStatusUseCase interface {
+		Execute(ctx context.Context, operationID, songID string) (model.OperationResult, error)
+	}
+)

--- a/microservices/audio_processor/tests/unit/audio_handler_test.go
+++ b/microservices/audio_processor/tests/unit/audio_handler_test.go
@@ -1,0 +1,138 @@
+package unit
+
+import (
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/interface/http/handler"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAudioHandler_InitiateDownload(t *testing.T) {
+	t.Run("Successful download initiation", func(t *testing.T) {
+		mockInitialDownloadUC := new(MockInitiateDownloadUC)
+		mockGetOperationStatusUC := new(MockGetOperationStatusUC)
+
+		handlerHttp := handler.NewAudioHandler(mockInitialDownloadUC, mockGetOperationStatusUC)
+
+		mockInitialDownloadUC.On("Execute", mock.Anything, "test_song").Return("operation_123", nil)
+
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/download?song=test_song", nil)
+
+		handlerHttp.InitiateDownload(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "operation_123")
+		mockInitialDownloadUC.AssertExpectations(t)
+	})
+
+	t.Run("Missing song parameter", func(t *testing.T) {
+		mockInitialDownloadUC := new(MockInitiateDownloadUC)
+		mockGetOperationStatusUC := new(MockGetOperationStatusUC)
+
+		handlerHttp := handler.NewAudioHandler(mockInitialDownloadUC, mockGetOperationStatusUC)
+
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/download", nil)
+
+		handlerHttp.InitiateDownload(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Falta el parametro 'song'")
+
+	})
+
+	t.Run("Use case error", func(t *testing.T) {
+		mockInitialDownloadUC := new(MockInitiateDownloadUC)
+		mockGetOperationStatusUC := new(MockGetOperationStatusUC)
+
+		mockInitialDownloadUC.On("Execute", mock.Anything, "test_song").Return("", errors.New("use case error"))
+
+		handlerHttp := handler.NewAudioHandler(mockInitialDownloadUC, mockGetOperationStatusUC)
+
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/download?song=test_song", nil)
+
+		handlerHttp.InitiateDownload(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Contains(t, w.Body.String(), "use case error")
+		mockInitialDownloadUC.AssertExpectations(t)
+	})
+}
+
+func TestAudioHandler_GetOperationStatus(t *testing.T) {
+	t.Run("Successful status retrieval", func(t *testing.T) {
+		mockInitialDownloadUC := new(MockInitiateDownloadUC)
+		mockGetOperationStatusUC := new(MockGetOperationStatusUC)
+
+		handlerHttp := handler.NewAudioHandler(mockInitialDownloadUC, mockGetOperationStatusUC)
+
+		expectedResult := model.OperationResult{
+			Status: "completed",
+			Data:   "some data",
+		}
+
+		mockGetOperationStatusUC.On("Execute", mock.Anything, "operation_123", "song_123").Return(expectedResult, nil)
+
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/status?operation_id=operation_123&song_id=song_123", nil)
+
+		handlerHttp.GetOperationStatus(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "completed")
+		assert.Contains(t, w.Body.String(), "some data")
+		mockGetOperationStatusUC.AssertExpectations(t)
+	})
+
+	t.Run("Missing parameters", func(t *testing.T) {
+		mockInitialDownloadUC := new(MockInitiateDownloadUC)
+		mockGetOperationStatusUC := new(MockGetOperationStatusUC)
+
+		handlerHttp := handler.NewAudioHandler(mockInitialDownloadUC, mockGetOperationStatusUC)
+
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/status", nil)
+
+		handlerHttp.GetOperationStatus(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Faltan los parámetros 'operationID' y/o 'songID'")
+	})
+
+	t.Run("Use case error", func(t *testing.T) {
+		mockInitialDownloadUC := new(MockInitiateDownloadUC)
+		mockGetOperationStatusUC := new(MockGetOperationStatusUC)
+
+		handlerHttp := handler.NewAudioHandler(mockInitialDownloadUC, mockGetOperationStatusUC)
+
+		mockGetOperationStatusUC.On("Execute", mock.Anything, "operation_123", "song_123").Return(model.OperationResult{}, errors.New("use case error"))
+
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/status?operation_id=operation_123&song_id=song_123", nil)
+
+		handlerHttp.GetOperationStatus(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Contains(t, w.Body.String(), "use case error")
+		mockGetOperationStatusUC.AssertExpectations(t)
+	})
+}

--- a/microservices/audio_processor/tests/unit/mocks.go
+++ b/microservices/audio_processor/tests/unit/mocks.go
@@ -37,6 +37,14 @@ type (
 	MockAudioProcessingService struct {
 		mock.Mock
 	}
+
+	MockInitiateDownloadUC struct {
+		mock.Mock
+	}
+
+	MockGetOperationStatusUC struct {
+		mock.Mock
+	}
 )
 
 func (m *MockOperationRepository) SaveOperationsResult(ctx context.Context, result model.OperationResult) error {
@@ -122,4 +130,14 @@ func (m *MockAudioProcessingService) StartOperation(ctx context.Context, videoID
 func (m *MockAudioProcessingService) ProcessAudio(ctx context.Context, operationID string, videoDetails api.VideoDetails) error {
 	args := m.Called(ctx, operationID, videoDetails)
 	return args.Error(0)
+}
+
+func (m *MockInitiateDownloadUC) Execute(ctx context.Context, song string) (string, error) {
+	args := m.Called(ctx, song)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockGetOperationStatusUC) Execute(ctx context.Context, operationID, songID string) (model.OperationResult, error) {
+	args := m.Called(ctx, operationID, songID)
+	return args.Get(0).(model.OperationResult), args.Error(1)
 }


### PR DESCRIPTION
### Descripción
Este pull request implementa el `AudioHandler`, encargado de manejar las solicitudes HTTP para iniciar descargas de audio y consultar el estado de las operaciones. También se agregan pruebas unitarias para verificar el comportamiento de los endpoints.

### Cambios Realizados
- **Implementación de `AudioHandler`**: Se creó el handler para manejar los siguientes endpoints:
  - **Iniciar descarga de audio**: Permite iniciar la descarga de audio a partir de un parámetro de búsqueda (`song`) y devuelve un `operation_id`.
  - **Consultar estado de la operación**: Permite verificar el estado de una operación de procesamiento de audio dado un `operationID` y `songID`.
  
- **Pruebas unitarias**: Se agregaron pruebas para cubrir los siguientes escenarios:
  - Verificar que se manejen correctamente las solicitudes inválidas (falta de parámetros).
  - Probar el flujo de descarga de audio exitoso.
  - Probar la recuperación del estado de una operación de audio.
  - Mocks de `InitiateDownloadUseCase` y `GetOperationStatusUseCase` para simular comportamiento en los tests.
  
### Escenarios Cubiertos en los Tests
- **Solicitud con parámetros faltantes**: Verifica que se manejen adecuadamente las solicitudes con parámetros incompletos, devolviendo errores claros.
- **Inicio de descarga exitoso**: Asegura que el flujo de inicio de descarga funcione correctamente y que se devuelva el `operation_id` esperado.
- **Consulta de estado de operación**: Valida que se obtenga el estado correcto de una operación en curso o finalizada.
