### PR TITLE
Fix: Buffer Overflow in yt-dlp Downloader and Improve Asynchronous Handling in Audio Processing

### DIFF
--- a/microservices/audio_processor/internal/interface/http/handler/audio_handler.go
+++ b/microservices/audio_processor/internal/interface/http/handler/audio_handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/usecase"
 	"github.com/gin-gonic/gin"
 	"net/http"
@@ -47,7 +46,7 @@ func (h *AudioHandler) GetOperationStatus(c *gin.Context) {
 		})
 		return
 	}
-	status, err := h.getOperationStatusUC.Execute(context.Background(), operationID, songID)
+	status, err := h.getOperationStatusUC.Execute(c.Request.Context(), operationID, songID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
Este PR incluye las siguientes mejoras y correcciones:

1. **Corrección del error `bufio.Scanner: token too long`**:
   - Se resolvió un problema donde el `bufio.Scanner` encontraba un desbordamiento de buffer (buffer overflow) al procesar tokens grandes en la salida estándar de errores (stderr) durante las descargas con yt-dlp.

2. **Mejoras en los tests de `InitiateDownloadUseCase`**:
   - Se mejoró el manejo de las pruebas para asegurar que el procesamiento de audio se maneje de forma asíncrona correctamente.
   - Se agregaron canales para garantizar que las goroutines finalicen antes de que el test termine, evitando condiciones de carrera.
   - Se añadió un test para verificar que el comportamiento sea el esperado cuando falla el procesamiento de audio.