### PR TITLE
Add health check endpoint for external services

### DIFF
--- a/microservices/audio_processor/cmd/server/server.go
+++ b/microservices/audio_processor/cmd/server/server.go
@@ -61,8 +61,9 @@ func StartServer() error {
 	getOperationStatus := usecase.NewGetOperationStatusUseCase(operationRepo)
 	initiateDownloadUC := usecase.NewInitiateDownloadUseCase(audioProcessingService, youtubeAPI)
 	audioHandler := handler.NewAudioHandler(initiateDownloadUC, getOperationStatus)
+	healthCheck := handler.NewHealthHandler(cfg.YouTubeApiKey)
 	r := gin.Default()
-	router.SetupRoutes(r, audioHandler)
+	router.SetupRoutes(r, audioHandler, healthCheck)
 
 	return r.Run(":8080")
 }

--- a/microservices/audio_processor/internal/infrastructure/api/dynamodb.go
+++ b/microservices/audio_processor/internal/infrastructure/api/dynamodb.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+func CheckDynamoDB() error {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"))
+	if err != nil {
+		return fmt.Errorf("error cargando configuración AWS: %w", err)
+	}
+
+	client := dynamodb.NewFromConfig(cfg)
+
+	_, err = client.ListTables(context.TODO(), &dynamodb.ListTablesInput{})
+	if err != nil {
+		return fmt.Errorf("error en listar las tablas: %w", err)
+	}
+	return nil
+}

--- a/microservices/audio_processor/internal/infrastructure/api/s3.go
+++ b/microservices/audio_processor/internal/infrastructure/api/s3.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func CheckS3() error {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"))
+	if err != nil {
+		return fmt.Errorf("error cargando configuración AWS: %w", err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+
+	_, err = client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	if err != nil {
+		return fmt.Errorf("error en listar buckets: %w", err)
+	}
+	return nil
+}

--- a/microservices/audio_processor/internal/infrastructure/api/youtube.go
+++ b/microservices/audio_processor/internal/infrastructure/api/youtube.go
@@ -174,3 +174,18 @@ func ExtractVideoIDFromURL(videoURL string) (string, error) {
 	}
 	return "", fmt.Errorf("URL de YouTube invalida: %s", videoURL)
 }
+
+func CheckYouTube(apiKey string) error {
+	endpoint := fmt.Sprintf("https://www.googleapis.com/youtube/v3/videos?id=dQw4w9WgXcQ&key=%s", apiKey)
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("YouTube API status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/microservices/audio_processor/internal/interface/http/handler/health.go
+++ b/microservices/audio_processor/internal/interface/http/handler/health.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/api"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type HealthHandler struct {
+	youtubeAPIKey string
+}
+
+func NewHealthHandler(youtubeAPIKey string) *HealthHandler {
+	return &HealthHandler{
+		youtubeAPIKey: youtubeAPIKey,
+	}
+}
+
+func (h *HealthHandler) HealthCheckHandler(c *gin.Context) {
+	services := map[string]func() error{
+		"DynamoDB": api.CheckDynamoDB,
+		"S3":       api.CheckS3,
+		"YouTube API": func() error {
+			return api.CheckYouTube(h.youtubeAPIKey)
+		},
+	}
+	results := make(map[string]string)
+	allHealthy := true
+
+	for name, check := range services {
+		if err := check(); err != nil {
+			results[name] = "indisponible" + err.Error()
+			allHealthy = false
+		} else {
+			results[name] = "saludable"
+		}
+	}
+
+	status := http.StatusOK
+	message := "Todos los servicios son saludables."
+	if !allHealthy {
+		status = http.StatusInternalServerError
+		message = "Uno o mas servicios no estan saludables"
+	}
+
+	c.JSON(status, gin.H{
+		"status":   message,
+		"services": results,
+	})
+}

--- a/microservices/audio_processor/internal/interface/router/routes.go
+++ b/microservices/audio_processor/internal/interface/router/routes.go
@@ -5,10 +5,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupRoutes(router *gin.Engine, audioHandler *handler.AudioHandler) {
+func SetupRoutes(router *gin.Engine, audioHandler *handler.AudioHandler, healthCheck *handler.HealthHandler) {
 	api := router.Group("/api")
 	{
 		api.POST("/audio/start", audioHandler.InitiateDownload)
 		api.GET("/audio/status", audioHandler.GetOperationStatus)
+		api.GET("/health", healthCheck.HealthCheckHandler)
 	}
 }


### PR DESCRIPTION
Este PR agrega un endpoint de health check que verifica el estado de los servicios externos utilizados por el microservicio. Se incluyen las siguientes verificaciones:
- **DynamoDB**
- **S3**
- **YouTube API**

El objetivo es asegurar que todos los servicios críticos estén funcionando correctamente antes de procesar las solicitudes. Si uno o más servicios fallan, el endpoint devolverá un estado de error con detalles sobre el servicio afectado.
