### PR TITLE
Refactor health checks to use context and async execution

### DIFF
--- a/microservices/audio_processor/cmd/server/server.go
+++ b/microservices/audio_processor/cmd/server/server.go
@@ -25,6 +25,8 @@ func StartServer() error {
 		YouTubeApiKey:         os.Getenv("YOUTUBE_API_KEY"),
 		SongsTable:            os.Getenv("DYNAMODB_TABLE_NAME_SONGS"),
 		OperationResultsTable: os.Getenv("DYNAMODB_TABLE_NAME_OPERATION"),
+		AccessKey:             os.Getenv("ACCESS_KEY"),
+		SecretKey:             os.Getenv("SECRET_KEY"),
 	}
 
 	log, err := logger.NewZapLogger()
@@ -61,7 +63,7 @@ func StartServer() error {
 	getOperationStatus := usecase.NewGetOperationStatusUseCase(operationRepo)
 	initiateDownloadUC := usecase.NewInitiateDownloadUseCase(audioProcessingService, youtubeAPI)
 	audioHandler := handler.NewAudioHandler(initiateDownloadUC, getOperationStatus)
-	healthCheck := handler.NewHealthHandler(cfg.YouTubeApiKey)
+	healthCheck := handler.NewHealthHandler(cfg)
 	r := gin.Default()
 	router.SetupRoutes(r, audioHandler, healthCheck)
 

--- a/microservices/audio_processor/internal/config/config.go
+++ b/microservices/audio_processor/internal/config/config.go
@@ -10,4 +10,6 @@ type Config struct {
 	OperationResultsTable string
 	SongsTable            string
 	YouTubeApiKey         string
+	AccessKey             string
+	SecretKey             string
 }

--- a/microservices/audio_processor/internal/infrastructure/api/dynamodb.go
+++ b/microservices/audio_processor/internal/infrastructure/api/dynamodb.go
@@ -3,21 +3,25 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/config"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cfgAws "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 )
 
-func CheckDynamoDB() error {
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"))
+func CheckDynamoDB(ctx context.Context, cfgApplication config.Config) error {
+	cfg, err := cfgAws.LoadDefaultConfig(ctx, cfgAws.WithRegion(cfgApplication.Region), cfgAws.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+		cfgApplication.AccessKey, cfgApplication.SecretKey, "")))
 	if err != nil {
 		return fmt.Errorf("error cargando configuración AWS: %w", err)
 	}
 
 	client := dynamodb.NewFromConfig(cfg)
 
-	_, err = client.ListTables(context.TODO(), &dynamodb.ListTablesInput{})
+	_, err = client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String(cfgApplication.OperationResultsTable)})
 	if err != nil {
-		return fmt.Errorf("error en listar las tablas: %w", err)
+		return fmt.Errorf("error al obtener info de la tabla: %w", err)
 	}
 	return nil
 }

--- a/microservices/audio_processor/internal/infrastructure/api/s3.go
+++ b/microservices/audio_processor/internal/infrastructure/api/s3.go
@@ -3,21 +3,25 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/config"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cfgAws "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-func CheckS3() error {
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"))
+func CheckS3(ctx context.Context, cfgApplication config.Config) error {
+	cfg, err := cfgAws.LoadDefaultConfig(ctx, cfgAws.WithRegion(cfgApplication.Region), cfgAws.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+		cfgApplication.AccessKey, cfgApplication.SecretKey, "")))
 	if err != nil {
 		return fmt.Errorf("error cargando configuración AWS: %w", err)
 	}
 
 	client := s3.NewFromConfig(cfg)
 
-	_, err = client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(cfgApplication.BucketName)})
 	if err != nil {
-		return fmt.Errorf("error en listar buckets: %w", err)
+		return fmt.Errorf("error en encontrar el bucket: %w", err)
 	}
 	return nil
 }

--- a/microservices/audio_processor/internal/infrastructure/api/youtube.go
+++ b/microservices/audio_processor/internal/infrastructure/api/youtube.go
@@ -175,9 +175,15 @@ func ExtractVideoIDFromURL(videoURL string) (string, error) {
 	return "", fmt.Errorf("URL de YouTube invalida: %s", videoURL)
 }
 
-func CheckYouTube(apiKey string) error {
+func CheckYouTube(ctx context.Context, apiKey string) error {
 	endpoint := fmt.Sprintf("https://www.googleapis.com/youtube/v3/videos?id=dQw4w9WgXcQ&key=%s", apiKey)
-	resp, err := http.Get(endpoint)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Se refactorizaron todas las funciones de verificación de estado para aceptar contexto (ctx) para un mejor manejo de solicitudes.
- Se pasó c.request.context de Gin a cada verificación de servicio.
- Implementé la ejecución asincrónica de comprobaciones de estado del servicio para mejorar el rendimiento.
- Se redujo el tiempo de respuesta de la verificación de estado de ~3,2 segundos a 694 ms.