### PR TITLE
Implement Local Storage for Audio Files

### DIFF
--- a/microservices/audio_processor/internal/domain/port/operation_repository.go
+++ b/microservices/audio_processor/internal/domain/port/operation_repository.go
@@ -7,7 +7,7 @@ import (
 
 // OperationRepository define las operaciones para manejar resultados de operación.
 type OperationRepository interface {
-	SaveOperationsResult(ctx context.Context, result model.OperationResult) error
+	SaveOperationsResult(ctx context.Context, result *model.OperationResult) error
 	GetOperationResult(ctx context.Context, id, songID string) (*model.OperationResult, error)
 	DeleteOperationResult(ctx context.Context, id, songID string) error
 	UpdateOperationStatus(ctx context.Context, operationID string, songID string, status string) error

--- a/microservices/audio_processor/internal/domain/service/audio_processing_service.go
+++ b/microservices/audio_processor/internal/domain/service/audio_processing_service.go
@@ -70,7 +70,7 @@ func NewAudioProcessingService(log logger.Logger, storage port.Storage,
 
 // StartOperation inicia una nueva operación de procesamiento de audio y guarda su estado inicial.
 func (a *AudioProcessingService) StartOperation(ctx context.Context, songID string) (string, string, error) {
-	operationResult := model.OperationResult{
+	operationResult := &model.OperationResult{
 		PK:     uuid.New().String(),
 		SK:     songID,
 		Status: statusInitiating,
@@ -158,8 +158,8 @@ func (a *AudioProcessingService) createMetadata(youtubeMetadata api.VideoDetails
 }
 
 // createSuccessResult crea un resultado de operación exitoso después del procesamiento de audio.
-func (a *AudioProcessingService) createSuccessResult(operationID string, metadata *model.Metadata, fileData model.FileData, attempts int) model.OperationResult {
-	return model.OperationResult{
+func (a *AudioProcessingService) createSuccessResult(operationID string, metadata *model.Metadata, fileData model.FileData, attempts int) *model.OperationResult {
+	return &model.OperationResult{
 		PK:             operationID,
 		SK:             metadata.VideoID,
 		Status:         statusSuccess,
@@ -175,7 +175,7 @@ func (a *AudioProcessingService) createSuccessResult(operationID string, metadat
 
 // handleFailedProcessing maneja el caso en que el procesamiento falla después de varios intentos.
 func (a *AudioProcessingService) handleFailedProcessing(ctx context.Context, operationID string, metadata model.Metadata) error {
-	result := model.OperationResult{
+	result := &model.OperationResult{
 		PK:             operationID,
 		SK:             metadata.VideoID,
 		Status:         statusFailed,

--- a/microservices/audio_processor/internal/infrastructure/repository/dynamodb/operation_repository.go
+++ b/microservices/audio_processor/internal/infrastructure/repository/dynamodb/operation_repository.go
@@ -39,7 +39,7 @@ func NewOperationStore(cfgApplication config.Config) (*OperationStore, error) {
 }
 
 // SaveOperationsResult guarda el resultado de una operación en DynamoDB. Genera un nuevo ID si es necesario.
-func (s *OperationStore) SaveOperationsResult(ctx context.Context, result model.OperationResult) error {
+func (s *OperationStore) SaveOperationsResult(ctx context.Context, result *model.OperationResult) error {
 	if result.PK == "" {
 		result.PK = uuid.New().String()
 	}

--- a/microservices/audio_processor/internal/infrastructure/storage/local/local_storage.go
+++ b/microservices/audio_processor/internal/infrastructure/storage/local/local_storage.go
@@ -1,0 +1,120 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type LocalStorage struct {
+	BasePath string
+}
+
+func NewLocalStorage(basePath string) (*LocalStorage, error) {
+	if err := os.MkdirAll(basePath, 0755); err != nil {
+		return nil, fmt.Errorf("error creando directorio base %s:%w", basePath, err)
+	}
+
+	testFile := filepath.Join(basePath, ".write_test")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		return nil, fmt.Errorf("el directorio %s no es escribible: %w", testFile, err)
+	}
+
+	defer func() {
+		if err := os.Remove(testFile); err != nil {
+			_ = fmt.Errorf("error al eliminar el archivo: %w", err)
+		}
+	}()
+
+	return &LocalStorage{BasePath: basePath}, nil
+}
+
+func (l *LocalStorage) UploadFile(ctx context.Context, key string, body io.Reader) error {
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("contexto cancelado durante la subida del archivo: %w", ctx.Err())
+	default:
+	}
+
+	if body == nil {
+		return fmt.Errorf("el body no puede ser nulo")
+	}
+
+	if !strings.HasSuffix(key, ".dca") {
+		key += ".dca"
+	}
+
+	fullPath := filepath.Join(l.BasePath, "audio", key)
+
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return fmt.Errorf("error creando directorio para %s: %w", fullPath, err)
+	}
+
+	file, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("error creando archivo %s: %w", fullPath, err)
+	}
+
+	defer func() {
+		if err := file.Close(); err != nil {
+			_ = fmt.Errorf("error al cerrar el archivo %s: %w", fullPath, err)
+		}
+	}()
+
+	buf := make([]byte, 32*1024)
+	_, err = io.CopyBuffer(file, body, buf)
+	if err != nil {
+		return fmt.Errorf("error escribiendo archivo %s: %w", fullPath, err)
+	}
+	return nil
+}
+
+func (l *LocalStorage) GetFileMetadata(ctx context.Context, key string) (*model.FileData, error) {
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("contexto cancelado durante la obtención de metadata: %w", ctx.Err())
+	default:
+	}
+
+	if !strings.HasSuffix(key, ".dca") {
+		key += ".dca"
+	}
+
+	fullPath := filepath.Join(l.BasePath, "audio", key)
+
+	fileInfo, err := os.Stat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("archivo %s no encontrado: %w", key, err)
+		}
+		return nil, fmt.Errorf("error obteniendo información del archivo %s: %w", key, err)
+	}
+	return &model.FileData{
+		FilePath:  "audio/" + key,
+		FileType:  "audio/dca",
+		FileSize:  FormatFileSize(fileInfo.Size()),
+		PublicURL: fmt.Sprintf("file://%s", fullPath),
+	}, nil
+}
+
+func FormatFileSize(sizeBytes int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+	switch {
+	case sizeBytes >= GB:
+		return fmt.Sprintf("%.2fGB", float64(sizeBytes)/float64(GB))
+	case sizeBytes >= MB:
+		return fmt.Sprintf("%.2fMB", float64(sizeBytes)/float64(MB))
+	case sizeBytes >= KB:
+		return fmt.Sprintf("%.2fKB", float64(sizeBytes)/float64(KB))
+	default:
+		return fmt.Sprintf("%dB", sizeBytes)
+	}
+}

--- a/microservices/audio_processor/tests/integration/mongo_repository_integration_test.go
+++ b/microservices/audio_processor/tests/integration/mongo_repository_integration_test.go
@@ -20,7 +20,7 @@ var mongoContainer *mongodb.MongoDBContainer
 
 func TestMain(t *testing.M) {
 	var err error
-	mongoContainer, err = mongodb.Run(context.Background(), "mongodb:6")
+	mongoContainer, err = mongodb.Run(context.Background(), "mongo:6")
 	if err != nil {
 		log.Fatalf("Error al iniciar el contendor de MongoDB: %v", err)
 	}

--- a/microservices/audio_processor/tests/integration/operation_store_integration_test.go
+++ b/microservices/audio_processor/tests/integration/operation_store_integration_test.go
@@ -25,7 +25,7 @@ func TestIntegrationOperationStore(t *testing.T) {
 	}
 
 	if cfg.OperationResultsTable == "" || cfg.Region == "" {
-		t.Fatal("DYNAMODB_TABLE_NAME_OPERATIONS y REGION no fueron seteados para los tests de integracion")
+		t.Fatal("DYNAMODB_TABLE_NAME_OPERATION y REGION no fueron seteados para los tests de integracion")
 	}
 
 	store, err := dynamodb.NewOperationStore(cfg)
@@ -44,7 +44,7 @@ func TestIntegrationOperationStore(t *testing.T) {
 		require.NoError(t, err)
 
 		// assert
-		assertOperationResultEqual(t, result, *retrievedResult)
+		assertOperationResultEqual(t, result, retrievedResult)
 
 		// cleanup
 		err = store.DeleteOperationResult(context.Background(), result.PK, result.SK)
@@ -133,8 +133,8 @@ func TestIntegrationOperationStore(t *testing.T) {
 	})
 }
 
-func createTestOperationResult(songID string) model.OperationResult {
-	return model.OperationResult{
+func createTestOperationResult(songID string) *model.OperationResult {
+	return &model.OperationResult{
 		PK:      uuid.New().String(),
 		SK:      songID,
 		Status:  "in_progress",
@@ -142,7 +142,7 @@ func createTestOperationResult(songID string) model.OperationResult {
 	}
 }
 
-func assertOperationResultEqual(t *testing.T, expected, actual model.OperationResult) {
+func assertOperationResultEqual(t *testing.T, expected, actual *model.OperationResult) {
 	assert.Equal(t, expected.PK, actual.PK)
 	assert.Equal(t, expected.SK, actual.SK)
 	assert.Equal(t, expected.Status, actual.Status)

--- a/microservices/audio_processor/tests/unit/audio_processing_service_test.go
+++ b/microservices/audio_processor/tests/unit/audio_processing_service_test.go
@@ -45,7 +45,7 @@ func TestAudioProcessingService(t *testing.T) {
 			mockStorage.On("UploadFile", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 			mockStorage.On("GetFileMetadata", mock.Anything, mock.Anything).Return(&model.FileData{}, nil)
 			mockMetadataRepo.On("SaveMetadata", mock.Anything, mock.AnythingOfType("*model.Metadata")).Return(nil)
-			mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("model.OperationResult")).Return(nil)
+			mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("*model.OperationResult")).Return(nil)
 			mockLogger.On("Info", mock.Anything, mock.Anything).Return()
 			mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
 			mockLogger.On("Error", mock.Anything, mock.Anything).Return()
@@ -82,7 +82,7 @@ func TestAudioProcessingService(t *testing.T) {
 		ctx := context.Background()
 		songID := "test-song-id"
 
-		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("model.OperationResult")).Return(errors.New("database error"))
+		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("*model.OperationResult")).Return(errors.New("database error"))
 
 		// Act
 		operationID, _, err := serviceAudio.StartOperation(ctx, songID)
@@ -124,7 +124,7 @@ func TestAudioProcessingService(t *testing.T) {
 			mockStorage.On("UploadFile", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 			mockStorage.On("GetFileMetadata", mock.Anything, mock.Anything).Return(&model.FileData{}, nil)
 			mockMetadataRepo.On("SaveMetadata", mock.Anything, mock.AnythingOfType("*model.Metadata")).Return(nil)
-			mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("model.OperationResult")).Return(nil)
+			mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("*model.OperationResult")).Return(nil)
 			mockLogger.On("Info", mock.Anything, mock.Anything).Return()
 			mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
 			mockLogger.On("Error", mock.Anything, mock.Anything).Return()
@@ -169,7 +169,7 @@ func TestAudioProcessingService(t *testing.T) {
 		mockAudioContent := bytes.NewBufferString("fake audio content")
 
 		mockDownloader.On("DownloadAudio", mock.Anything, mock.AnythingOfType("string")).Return(mockAudioContent, errors.New("download error"))
-		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("model.OperationResult")).Return(nil)
+		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("*model.OperationResult")).Return(nil)
 		mockLogger.On("Error", mock.Anything, mock.Anything).Return()
 
 		// Act
@@ -212,7 +212,7 @@ func TestAudioProcessingService(t *testing.T) {
 		mockStorage.On("UploadFile", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 		mockStorage.On("GetFileMetadata", mock.Anything, mock.Anything).Return(&model.FileData{}, nil)
 		mockMetadataRepo.On("SaveMetadata", mock.Anything, mock.AnythingOfType("*model.Metadata")).Return(errors.New("metadata save error"))
-		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("model.OperationResult")).Return(nil)
+		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("*model.OperationResult")).Return(nil)
 		mockLogger.On("Error", mock.Anything, mock.Anything).Return()
 		mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
 
@@ -258,7 +258,7 @@ func TestAudioProcessingService(t *testing.T) {
 		mockStorage.On("UploadFile", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 		mockStorage.On("GetFileMetadata", mock.Anything, mock.Anything).Return(&model.FileData{}, nil)
 		mockMetadataRepo.On("SaveMetadata", mock.Anything, mock.AnythingOfType("*model.Metadata")).Return(errors.New("metadata save error"))
-		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("model.OperationResult")).Return(nil)
+		mockOperationRepo.On("SaveOperationsResult", mock.Anything, mock.AnythingOfType("*model.OperationResult")).Return(nil)
 		mockLogger.On("Error", mock.Anything, mock.Anything).Return()
 		mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
 

--- a/microservices/audio_processor/tests/unit/local_storage_test.go
+++ b/microservices/audio_processor/tests/unit/local_storage_test.go
@@ -1,0 +1,299 @@
+package unit
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/infrastructure/storage/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalStorage(t *testing.T) {
+	setupTest := func(t *testing.T) (*local.LocalStorage, string) {
+		tempDir, err := os.MkdirTemp("", "storage-test-*")
+		assert.NoError(t, err, "Error creando directorio temporal")
+
+		storage, err := local.NewLocalStorage(tempDir)
+		assert.NoError(t, err, "Error creando LocalStorage")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Fatalf("Error al eliminar el directorio temporal: %s", err)
+			}
+		})
+		return storage, tempDir
+	}
+
+	t.Run("NewLocalStorage", func(t *testing.T) {
+		t.Run("should create base directory if it doesn't exist", func(t *testing.T) {
+			// arrange
+			tempDir := filepath.Join(os.TempDir(), "storage-test-new")
+			defer func() {
+				if err := os.RemoveAll(tempDir); err != nil {
+					t.Fatalf("Error al eliminar el directorio temporal: %s", err)
+				}
+			}()
+
+			// act
+			storage, err := local.NewLocalStorage(tempDir)
+
+			// assert
+			assert.NoError(t, err)
+			assert.NotNil(t, storage)
+			assert.DirExists(t, tempDir)
+		})
+
+		t.Run("should fail if you don't have write permissions", func(t *testing.T) {
+			// arrange
+			tempDir := filepath.Join(os.TempDir(), "storage-test-readonly")
+
+			if err := os.MkdirAll(tempDir, 0555); err != nil { // solo lectura
+				t.Fatalf("Error al creando el directorio temporal: %s", err)
+			}
+
+			defer func() {
+				if err := os.RemoveAll(tempDir); err != nil {
+					t.Fatalf("Error al eliminar el directorio temporal: %s", err)
+				}
+			}()
+
+			// act
+			storage, err := local.NewLocalStorage(tempDir)
+
+			// assert
+			assert.Error(t, err)
+			assert.Nil(t, storage)
+			assert.Contains(t, err.Error(), "no es escribible")
+		})
+	})
+
+	t.Run("UploadFile", func(t *testing.T) {
+		t.Run("should save DCA file correctly", func(t *testing.T) {
+			// arrange
+			storage, tempDir := setupTest(t)
+			content := "contenido de prueba"
+			key := ".dca"
+			ctx := context.Background()
+
+			// act
+			err := storage.UploadFile(ctx, key, strings.NewReader(content))
+
+			// assert
+			assert.NoError(t, err)
+			expectedPath := filepath.Join(tempDir, "audio", key)
+			assert.FileExists(t, expectedPath)
+
+			// verificar contenido
+			savedContent, err := os.ReadFile(expectedPath)
+			assert.NoError(t, err)
+			assert.Equal(t, content, string(savedContent))
+		})
+
+		t.Run("should add .dca extension if missing", func(t *testing.T) {
+			// arrange
+			storage, tempDir := setupTest(t)
+			content := "contenido de prueba"
+			key := "test"
+			ctx := context.Background()
+
+			// act
+			err := storage.UploadFile(ctx, key, strings.NewReader(content))
+
+			// assert
+			assert.NoError(t, err)
+			expectedPath := filepath.Join(tempDir, "audio", key+".dca")
+			assert.FileExists(t, expectedPath)
+		})
+
+		t.Run("should handle error when context is canceled", func(t *testing.T) {
+			// arrange
+			storage, _ := setupTest(t)
+			content := "contenido de prueba"
+			key := ".dca"
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			// act
+			err := storage.UploadFile(ctx, key, strings.NewReader(content))
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "contexto cancelado durante la subida del archivo")
+		})
+
+		t.Run("should handle body null", func(t *testing.T) {
+			// arrange
+			storage, _ := setupTest(t)
+			ctx := context.Background()
+
+			// act
+			err := storage.UploadFile(ctx, "test.dca", nil)
+
+			// assert
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "el body no puede ser nulo")
+		})
+
+		t.Run("should handle large files correctly", func(t *testing.T) {
+			// arrange
+			storage, _ := setupTest(t)
+			largeContent := bytes.Repeat([]byte("a"), 1024*1024) // 1MB de datos
+			ctx := context.Background()
+
+			// act
+			err := storage.UploadFile(ctx, "large.dca", bytes.NewReader(largeContent))
+
+			// assert
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("GetFileMetadata", func(t *testing.T) {
+		t.Run("should get metadata correctly", func(t *testing.T) {
+			// arrange
+			storage, _ := setupTest(t)
+			content := "contenido de prueba"
+			key := "test.dca"
+			ctx := context.Background()
+
+			err := storage.UploadFile(ctx, key, strings.NewReader(content))
+			assert.NoError(t, err)
+
+			// act
+			metadata, err := storage.GetFileMetadata(ctx, key)
+
+			// assert
+			assert.NoError(t, err)
+			assert.NotNil(t, metadata)
+			assert.Equal(t, "audio/"+key, metadata.FilePath)
+			assert.Equal(t, "audio/dca", metadata.FileType)
+			assert.Contains(t, metadata.FileSize, "B") // Debería tener el formato correcto
+		})
+
+		t.Run("should handle non-existing file", func(t *testing.T) {
+			// arrange
+			storage, _ := setupTest(t)
+			ctx := context.Background()
+
+			// act
+			metadata, err := storage.GetFileMetadata(ctx, "no-exist.dca")
+
+			// assert
+			assert.Error(t, err)
+			assert.Nil(t, metadata)
+			assert.Contains(t, err.Error(), "no encontrado")
+
+		})
+
+		t.Run("should add .dca extension if missing", func(t *testing.T) {
+			// Arrange
+			storage, _ := setupTest(t)
+			content := "contenido de prueba"
+			ctx := context.Background()
+
+			err := storage.UploadFile(ctx, "test", strings.NewReader(content))
+			assert.NoError(t, err)
+
+			// Act
+			metadata, err := storage.GetFileMetadata(ctx, "test")
+
+			// Assert
+			assert.NoError(t, err)
+			assert.NotNil(t, metadata)
+			assert.Equal(t, "audio/test.dca", metadata.FilePath)
+		})
+
+		t.Run("should handle canceled context", func(t *testing.T) {
+			// Arrange
+			storage, _ := setupTest(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			// Act
+			metadata, err := storage.GetFileMetadata(ctx, "test.dca")
+
+			// Assert
+			assert.Error(t, err)
+			assert.Nil(t, metadata)
+			assert.Contains(t, err.Error(), "contexto cancelado")
+		})
+	})
+
+	t.Run("formatFileSize", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			size     int64
+			expected string
+		}{
+			{"bytes", 500, "500B"},
+			{"kilobytes", 1024 * 2, "2.00KB"},
+			{"megabytes", 1024 * 1024 * 3, "3.00MB"},
+			{"gigabytes", 1024 * 1024 * 1024 * 4, "4.00GB"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// Act
+				result := local.FormatFileSize(tt.size)
+				// Assert
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	// arrange
+	storage, _ := setupTest(t)
+	ctx := context.Background()
+	numGoroutines := 10
+	done := make(chan bool)
+
+	// act
+	for i := 0; i < numGoroutines; i++ {
+		go func(index int) {
+			key := fmt.Sprintf("concurrent_%d.dca", index)
+			content := fmt.Sprintf("content_%d", index)
+
+			err := storage.UploadFile(ctx, key, strings.NewReader(content))
+			assert.NoError(t, err)
+
+			metadata, err := storage.GetFileMetadata(ctx, key)
+			assert.NoError(t, err)
+			assert.NotNil(t, metadata)
+
+			done <- true
+		}(i)
+	}
+
+	// assert
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case <-done:
+			continue
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout esperando por goroutines")
+		}
+	}
+}
+
+func setupTest(t *testing.T) (*local.LocalStorage, string) {
+	tempDir, err := os.MkdirTemp("", "storage-test-*")
+	require.NoError(t, err, "Error creando directorio temporal")
+
+	storage, err := local.NewLocalStorage(tempDir)
+	require.NoError(t, err, "Error creando LocalStorage")
+
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("Error al eliminar directorio: %s", err)
+		}
+	})
+
+	return storage, tempDir
+}

--- a/microservices/audio_processor/tests/unit/mocks.go
+++ b/microservices/audio_processor/tests/unit/mocks.go
@@ -214,7 +214,7 @@ func (m *MockStorageS3API) PutObject(ctx context.Context, params *s3.PutObjectIn
 	return args.Get(0).(*s3.PutObjectOutput), args.Error(1)
 }
 
-func (m *MockOperationRepository) SaveOperationsResult(ctx context.Context, result model.OperationResult) error {
+func (m *MockOperationRepository) SaveOperationsResult(ctx context.Context, result *model.OperationResult) error {
 	args := m.Called(ctx, result)
 	return args.Error(0)
 }

--- a/microservices/audio_processor/tests/unit/operation_store_test.go
+++ b/microservices/audio_processor/tests/unit/operation_store_test.go
@@ -23,7 +23,7 @@ func TestSaveOperationResult(t *testing.T) {
 			},
 		}
 
-		result := model.OperationResult{
+		result := &model.OperationResult{
 			SK: "test-song-id",
 		}
 
@@ -45,7 +45,7 @@ func TestSaveOperationResult(t *testing.T) {
 			},
 		}
 
-		result := model.OperationResult{
+		result := &model.OperationResult{
 			SK: "test-song-id",
 		}
 


### PR DESCRIPTION
### Resumen
Este PR agrega una solución de almacenamiento local para manejar la persistencia de archivos de audio directamente en el servidor, en lugar de utilizar almacenamiento en memoria o basado en la nube. Esta implementación está destinada a entornos de desarrollo local o configuraciones donde el almacenamiento en la nube no está disponible.

### Cambios
- Creé una nueva implementación de "almacenamiento" para almacenar archivos de audio localmente en el sistema de archivos.
- Configuración agregada para permitir elegir entre almacenamiento local y otras soluciones de almacenamiento.
- Lógica de servicio relacionada actualizada para leer/escribir archivos de audio desde/hacia el sistema de archivos local.

### Motivación
Almacenar archivos de audio localmente es una alternativa conveniente al almacenamiento en memoria, especialmente cuando se trabaja con archivos más grandes (de 1 MB a 50 MB). Este enfoque mejora la persistencia de los archivos durante los reinicios del servicio local sin requerir almacenamiento en la nube.

### Pruebas
- Almacenamiento y recuperación de archivos verificados en el sistema de archivos local.
- El almacenamiento confirmado funciona como se esperaba con tamaños de archivos de audio típicos (1 MB - 50 MB).