### PR TITLE
Add Kafka StatefulSet configuration for cluster setup

### DIFF
--- a/k8s/base/stateful/kafka/service.yaml
+++ b/k8s/base/stateful/kafka/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-headless
+spec:
+  clusterIP: None
+  selector:
+    app: kafka
+  ports:
+  - port: 9092
+    name: external
+  - port: 29092
+    name: internal

--- a/k8s/base/stateful/kafka/statefulset.yaml
+++ b/k8s/base/stateful/kafka/statefulset.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  serviceName: kafka-headless
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+      - name: kafka
+        image: confluentinc/cp-kafka:latest
+        ports:
+        - containerPort: 9092
+          name: external
+        - containerPort: 29092
+          name: internal
+        env:
+        - name: KAFKA_BROKER_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: "zookeeper-headless:2181"
+        - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+          value: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+        - name: KAFKA_LISTENERS
+          value: "INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: "INTERNAL://$(POD_NAME).kafka-headless:29092,EXTERNAL://$(POD_NAME).kafka-headless:9092"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: KAFKA_INTER_BROKER_LISTENER_NAME
+          value: "INTERNAL"
+        - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+          value: "3"
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/kafka/data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi


### PR DESCRIPTION
Este Pull Request introduce una configuración de `StatefulSet` para establecer un clúster de Kafka en Kubernetes. A continuación se detallan los cambios realizados:

- Se ha creado un `StatefulSet` llamado **kafka** con 3 réplicas para asegurar la alta disponibilidad.
- Se ha definido un servicio **kafka-headless** para permitir la comunicación interna entre los pods.
- Se han configurado las variables de entorno necesarias, incluyendo:
  - `KAFKA_BROKER_ID` para identificar cada broker.
  - `KAFKA_ZOOKEEPER_CONNECT` para conectar a Zookeeper.
  - `KAFKA_LISTENERS` y `KAFKA_ADVERTISED_LISTENERS` para la configuración de puertos internos y externos.
  - `KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR` configurado en 3 para asegurar la durabilidad de los datos.
- Se ha añadido un volumen persistente para almacenar los datos de Kafka.
