### PR TITLE
Add Zookeeper StatefulSet and headless service configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ButakeroBot</title>
+    <title>ButakeroMusicBotGo</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -14,14 +14,24 @@
         }
         .container {
             width: 80%;
-            margin: auto;
-            overflow: hidden;
+            max-width: 1000px;
+            margin: 40px auto;
             background: #fff;
             padding: 20px;
+            border-radius: 8px;
             box-shadow: 0 0 10px rgba(0,0,0,0.1);
         }
         h1 {
+            color: #007bff;
+            text-align: center;
+        }
+        p {
             color: #333;
+            text-align: justify;
+        }
+        ul {
+            list-style-type: square;
+            padding-left: 20px;
         }
         a {
             color: #007bff;
@@ -34,14 +44,16 @@
 </head>
 <body>
     <div class="container">
-        <h1>Bienvenido a ButakeroBot</h1>
-        <p>ButakeroBot es un bot de música para Discord que te permite reproducir tus canciones favoritas y obtener recomendaciones personalizadas.</p>
-        <p>Para obtener más información, consulta los siguientes documentos:</p>
+        <h1>Bienvenido a ButakeroMusicBotGo</h1>
+        <p>ButakeroMusicBotGo es un bot de música para Discord desarrollado en GoLang. Permite reproducir canciones de YouTube en tus servidores de Discord, y estamos trabajando activamente en añadir soporte para más plataformas de música.</p>
+        <p>Este proyecto es mantenido por un solo desarrollador, y aunque no es muy conocido aún, seguimos agregando nuevas funcionalidades de manera regular.</p>
+        <h2>Documentación</h2>
         <ul>
             <li><a href="terminos-de-servicio.html">Términos de Servicio</a></li>
             <li><a href="politica-de-privacidad.html">Política de Privacidad</a></li>
         </ul>
-        <p>Si tienes alguna pregunta, no dudes en contactarnos en <a href="mailto:viltetomas2003@gmail.com">viltetomas2003@gmail.com</a>.</p>
+        <h2>Contacto</h2>
+        <p>Si tienes alguna pregunta o sugerencia, no dudes en enviarnos un correo a <a href="mailto:viltetomas2003@gmail.com">viltetomas2003@gmail.com</a>.</p>
     </div>
 </body>
 </html>

--- a/k8s/base/stateful/zookeeper/service.yaml
+++ b/k8s/base/stateful/zookeeper/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper-headless
+spec:
+  clusterIP: None
+  selector:
+    app: zookeeper
+  ports:
+    - port: 2181
+      name: client
+    - port: 2888
+      name: server
+    - port: 3888
+      name: leader-election

--- a/k8s/base/stateful/zookeeper/statefulset.yaml
+++ b/k8s/base/stateful/zookeeper/statefulset.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zookeeper
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper
+  serviceName: zookeeper-headless
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+      - name: zookeeper
+        image: confluentinc/cp-zookeeper:latest
+        ports:
+        - containerPort: 2181
+          name: client
+        - containerPort: 2888
+          name: server
+        - containerPort: 3888
+          name: leader-election
+        env:
+        - name: ZOOKEEPER_CLIENT_PORT
+          value: "2181"
+        - name: ZOOKEEPER_TICK_TIME
+          value: "2000"
+        - name: ZOOKEEPER_INIT_LIMIT
+          value: "5"
+        - name: ZOOKEEPER_SYNC_LIMIT
+          value: "2"
+        - name: ZOOKEEPER_SERVER_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['zookeeper/server-id']
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/zookeeper/data
+        - name: datalog
+          mountPath: /var/lib/zookeeper/log
+      initContainers:
+      - name: init-server-id
+        image: busybox
+        command: ['sh', '-c', 'echo $(expr $HOSTNAME : ".*-\([0-9]*\)") > /data/myid']
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 10Gi
+  - metadata:
+      name: datalog
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
Este Pull Request introduce la configuración del `StatefulSet` para Zookeeper junto con un servicio *headless*. A continuación se detallan los cambios realizados:

- Se ha creado un `StatefulSet` llamado **zookeeper** con 3 réplicas para garantizar la alta disponibilidad.
- Se ha definido un servicio **zookeeper-headless** para permitir la comunicación interna entre los pods.
- En el `StatefulSet`, se han configurado los puertos necesarios:
  - **2181** para el cliente.
  - **2888** para la comunicación entre servidores.
  - **3888** para la elección del líder.
- Se han establecido las variables de entorno requeridas, incluyendo:
  - `ZOOKEEPER_CLIENT_PORT` para definir el puerto del cliente.
  - `ZOOKEEPER_TICK_TIME`, `ZOOKEEPER_INIT_LIMIT`, y `ZOOKEEPER_SYNC_LIMIT` para la configuración de Zookeeper.
  - `ZOOKEEPER_SERVER_ID` para identificar cada servidor utilizando el nombre del pod.
- Se ha añadido un init container llamado **init-server-id** que establece el ID del servidor Zookeeper.
- Se han creado volúmenes persistentes para almacenar los datos y los logs de Zookeeper.
