### PR TITLE
Add MongoDB StatefulSet with health checks and initialization

### DIFF
--- a/k8s/base/secrets/mongodb-secret.yaml
+++ b/k8s/base/secrets/mongodb-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+type: Opaque
+stringData:
+  MONGO_USER: root
+  MONGO_PASSWORD: root

--- a/k8s/base/stateful/mongodb/service.yaml
+++ b/k8s/base/stateful/mongodb/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb-headless
+spec:
+  clusterIP: None
+  selector:
+    app: mongodb
+  ports:
+  - port: 27017
+    targetPort: 27017
+    name: mongodb

--- a/k8s/base/stateful/mongodb/statefulset.yaml
+++ b/k8s/base/stateful/mongodb/statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+spec:
+  selector:
+    matchLabels:
+      app: mongodb
+  serviceName: mongodb-headless
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      containers:
+      - name: mongodb
+        image: mongo:6
+        startupProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+        ports:
+        - containerPort: 27017
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: app-secrets
+              key: MONGO_USER
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: app-secrets
+              key: MONGO_PASSWORD
+        - name: MONGO_INITDB_DATABASE
+          value: "audio_service_db"
+        command:
+        - mongod
+        - "--bind_ip_all"
+        - "--replSet"
+        - "rs0"
+        volumeMounts:
+        - name: data
+          mountPath: /data/db
+        livenessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - mongosh
+            - --eval
+            - "db.adminCommand('ping')"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi


### PR DESCRIPTION
Este Pull Request introduce la configuración del `StatefulSet` para MongoDB. A continuación se detallan los cambios realizados:

- Se ha creado un `StatefulSet` llamado **mongodb** con 3 réplicas para garantizar la alta disponibilidad.
- Se ha definido un servicio *headless* llamado **mongodb-headless** para permitir la comunicación interna entre los pods.
- Se han configurado los puertos necesarios:
  - **27017** para la comunicación con el cliente.
- Se ha implementado un *startup probe* para verificar que MongoDB esté funcionando correctamente al iniciar el contenedor, ejecutando el comando `db.adminCommand('ping')`.
- Se han añadido pruebas de salud:
  - **Liveness Probe**: verifica que el contenedor de MongoDB esté vivo.
  - **Readiness Probe**: asegura que el contenedor esté listo para recibir tráfico.
- Se han establecido las variables de entorno necesarias para la inicialización de MongoDB, incluyendo el nombre de usuario y la contraseña, que se obtienen de un secreto llamado **app-secrets**.
- Se ha configurado MongoDB para usar un conjunto de réplicas con el nombre **rs0** y se ha especificado el montaje de un volumen para persistir los datos.
