### PR TITLE
Add Kubernetes resources for backend service

### DIFF
--- a/k8s/base/backend/configmap.yaml
+++ b/k8s/base/backend/configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  environment: "local"
+  GIN_MODE: "release"
+  MESSAGING_TYPE: "kafka"
+  STORAGE_TYPE: "local"
+  DB_TYPE: "mongodb"
+  MONGO_PORT: "27017"
+  MONGO_DATABASE: "audio_service_db"
+  MONGO_SONGS_COLLECTION: "songs"
+  MONGO_OPERATION_RESULTS_COLLECTION: "operations"
+  BASE_PATH: "/data/audio"
+  TOPIC: "notification"
+  OAUTH2: "false"
+  config.yaml: |
+    environment: ${ENV}
+    gin:
+      mode: ${GIN_MODE}
+
+    service:
+      max_attempts: 3
+      timeout: "1m"
+
+    api:
+      youtube:
+        api_key: ${YOUTUBE_API_KEY}
+      oauth2:
+        enabled: ${OAUTH2}
+
+    messaging:
+      type: ${MESSAGING_TYPE}
+      kafka:
+        brokers: [${KAFKA_BROKERS}]
+        topic: ${TOPIC}
+
+    storage:
+      type: ${STORAGE_TYPE}
+      local:
+        base_path: ${BASE_PATH}
+
+    database:
+      type: ${DB_TYPE}
+      mongodb:
+        hosts:
+          - "${MONGO_HOST_0}"  
+          - "${MONGO_HOST_1}" 
+          - "${MONGO_HOST_2}"
+        port: ${MONGO_PORT}
+        user: ${MONGO_USER}
+        password: ${MONGO_PASSWORD}
+        database: ${MONGO_DATABASE}
+        collections:
+          songs: ${MONGO_SONGS_COLLECTION}
+          operations: ${MONGO_OPERATION_RESULTS_COLLECTION}

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+      - name: backend
+        image: tomasvilte/music-downloader-service:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: ENV
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: environment
+        - name: GIN_MODE
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: GIN_MODE
+        - name: MONGO_HOST
+          value: "mongodb-headless"
+        - name: MONGO_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: MONGO_PORT
+        - name: MONGO_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: MONGO_DATABASE
+        - name: MONGO_SONGS_COLLECTION
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: MONGO_SONGS_COLLECTION
+        - name: MONGO_OPERATION_RESULTS_COLLECTION
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: MONGO_OPERATION_RESULTS_COLLECTION
+        - name: KAFKA_BROKERS
+          value: "kafka-headless:29092"
+        - name: TOPIC
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: TOPIC
+        - name: MESSAGING_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: MESSAGING_TYPE
+        - name: STORAGE_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: STORAGE_TYPE
+        - name: BASE_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: BASE_PATH
+        - name: MONGO_USER 
+          valueFrom:
+            secretKeyRef:
+              name: backend-secret
+              key: MONGO_USER
+        - name: MONGO_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: backend-secret
+              key: MONGO_PASSWORD
+        - name: YOUTUBE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: backend-secret
+              key: YOUTUBE_API_KEY
+        - name: MONGO_HOST_0
+          value: "mongo-0.mongodb-service-cluster"
+        - name: MONGO_HOST_1
+          value: "mongo-1.mongodb-service-cluster"
+        - name: MONGO_HOST_2
+          value: "mongo-2.mongodb-service-cluster"
+        volumeMounts:
+        - name: config-volume
+          mountPath: /root/config.yaml
+          subPath: config.yaml
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+      volumes:
+      - name: config-volume
+        configMap:
+          name: app-config

--- a/k8s/base/backend/service.yaml
+++ b/k8s/base/backend/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # Secrets
+  - secrets/mongodb-secret.yaml
+  - secrets/backend-secret.yaml
+
+  # Stateful Services
+  - stateful/zookeeper/service.yaml
+  - stateful/zookeeper/statefulset.yaml
+  - stateful/kafka/service.yaml
+  - stateful/kafka/statefulset.yaml
+  - stateful/mongodb/mongo-persistentvolume.yaml
+  - stateful/mongodb/service.yaml
+  - stateful/mongodb/statefulset.yaml
+
+  # Backend services
+  - backend/configmap.yaml
+  - backend/service.yaml
+  - backend/deployment.yaml

--- a/k8s/base/secrets/backend-secret.yaml
+++ b/k8s/base/secrets/backend-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-secret
+type: Opaque
+stringData:
+  YOUTUBE_API_KEY: "${YOUTUBE_API_KEY}"
+  MONGO_USER: "root"
+  MONGO_PASSWORD: "root"


### PR DESCRIPTION
Se agregaron los recursos necesarios para la implementación del servicio backend. Esto incluye:

- **Secret**: Se creó un secreto `backend-secret` para almacenar las credenciales de MongoDB y la clave de API de YouTube.
- **ConfigMap**: Se configuró un `ConfigMap` llamado `app-config` que contiene las configuraciones del entorno y otros parámetros del servicio.
- **Service**: Se creó el servicio `backend` para exponer el backend en el puerto 80.
- **Deployment**: Se implementó el despliegue del backend con tres réplicas, configurando las variables de entorno necesarias y las sondas de salud.