### PR TITLE
Refactor Health Checks and Update Docker Compose for MongoDB Replica Set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /microservices/audio_processor/credentials.env
 /microservices/audio_processor/credentials_aws.env
 /microservices/audio_processor/test_local.env
+/microservices/audio_processor/rs_keyfile

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # Secrets
+  - secrets/mongodb-secret.yaml
+  - secrets/backend-secret.yaml
+
+  # Stateful Services
+  - stateful/zookeeper/service.yaml
+  - stateful/zookeeper/statefulset.yaml
+  - stateful/kafka/service.yaml
+  - stateful/kafka/statefulset.yaml
+  - stateful/mongodb/mongo-persistentvolume.yaml
+  - stateful/mongodb/service.yaml
+  - stateful/mongodb/statefulset.yaml
+
+  # Backend services
+  - backend/configmap.yaml
+  - backend/service.yaml
+  - backend/deployment.yaml

--- a/microservices/audio_processor/cmd/server/server.go
+++ b/microservices/audio_processor/cmd/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/config"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/factory"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/service"
@@ -16,10 +17,11 @@ import (
 )
 
 func StartServer() error {
-	cfg, err := config.LoadConfig("config.yaml")
+	cfg, err := config.LoadConfig("./configurations/config.yaml")
 	if err != nil {
 		return err
 	}
+	fmt.Println(cfg.Database.Mongo.Host)
 
 	var envFactory factory.EnvironmentFactory
 	if cfg.Environment == "aws" {

--- a/microservices/audio_processor/docker-compose.yml
+++ b/microservices/audio_processor/docker-compose.yml
@@ -37,8 +37,9 @@ services:
       - test-application
 
   mongodb:
-    image: mongo:6
+    image: mongo:8
     container_name: mongodb
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017", "--keyFile", "/etc/mongodb/pki/keyfile"]
     environment:
       MONGO_INITDB_DATABASE: audio_service_db
       MONGO_INITDB_ROOT_USERNAME: root
@@ -47,14 +48,15 @@ services:
       - "27017:27017"
     volumes:
       - mongo_data:/data/db
+      - ${PWD}/rs_keyfile:/etc/mongodb/pki/keyfile
     networks:
       - test-application
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 40s
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'mongodb:27017'}]}) }"| mongosh --port 27017 -u root -p root --authenticationDatabase admin
+      interval: 5s
+      timeout: 15s
+      retries: 7
+      start_period: 15s
 
   backend:
     build:
@@ -67,13 +69,13 @@ services:
         condition: service_healthy
     container_name: backend-application
     env_file:
-      - ./credentials_aws.env
+      - ./test_local.env
     ports:
       - "8080:8080"
     networks:
       - test-application
     volumes:
-      - ./configurations/config.yaml:/root/config.yaml
+      - ./configurations/config.yaml:/root/configurations/config.yaml
     
 volumes:
   mongo_data:

--- a/microservices/audio_processor/internal/config/validation.go
+++ b/microservices/audio_processor/internal/config/validation.go
@@ -197,10 +197,16 @@ func (mc *MongoConfig) Validate() error {
 		errors = append(errors, "operations es necesario")
 	}
 
+	validHost := false
 	for _, host := range mc.Host {
-		if host == "" {
-			errors = append(errors, "host es necesario")
+		if host != "" {
+			validHost = true
+			break
 		}
+	}
+
+	if !validHost {
+		errors = append(errors, "al menos un host es necesario")
 	}
 
 	if len(errors) > 0 {

--- a/microservices/audio_processor/internal/infrastructure/api/mongodb.go
+++ b/microservices/audio_processor/internal/infrastructure/api/mongodb.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/config"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"strings"
+	"time"
+)
+
+func CheckMongoDB(ctx context.Context, cfgApplication *config.Config) error {
+	uri := buildMongoURI(cfgApplication)
+
+	clientOptions := options.Client().
+		ApplyURI(uri).
+		SetServerSelectionTimeout(10 * time.Second).
+		SetConnectTimeout(10 * time.Second)
+
+	client, err := mongo.Connect(ctx, clientOptions)
+	if err != nil {
+		return fmt.Errorf("erorr conectando a MongoDB: %w", err)
+	}
+	defer client.Disconnect(ctx)
+
+	err = client.Ping(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error al hacer ping a MongoDB: %w", err)
+	}
+
+	cmd := bson.D{{"replSetGetStatus", 1}}
+	var result bson.M
+	err = client.Database("admin").RunCommand(ctx, cmd).Decode(&result)
+	if err != nil {
+		return fmt.Errorf("error al obtener estado del replica set: %w", err)
+	}
+
+	members, ok := result["members"].(primitive.A)
+	if !ok {
+		return fmt.Errorf("formato inesperado en la respuesta del replica set")
+	}
+
+	hasPrimary := false
+	for _, member := range members {
+		m := member.(bson.M)
+		if state, ok := m["stateStr"].(string); ok && state == "PRIMARY" {
+			hasPrimary = true
+			break
+		}
+	}
+
+	if !hasPrimary {
+		return fmt.Errorf("no se encontró un nodo primario en el replica set")
+	}
+
+	db := client.Database(cfgApplication.Database.Mongo.Database)
+
+	collections, err := db.ListCollectionNames(ctx, bson.D{{"name", cfgApplication.Database.Mongo.Collections.Operations}})
+	if err != nil {
+		return fmt.Errorf("error al listar colecciones: %w", err)
+	}
+
+	if len(collections) == 0 {
+		return fmt.Errorf("la colección %s no existe", cfgApplication.Database.Mongo.Collections.Operations)
+	}
+
+	return nil
+}
+
+func buildMongoURI(cfg *config.Config) string {
+	hostList := strings.Join(cfg.Database.Mongo.Host, ",")
+	return fmt.Sprintf("mongodb://%s:%s@%s/?replicaSet=rs0",
+		cfg.Database.Mongo.User,
+		cfg.Database.Mongo.Password,
+		hostList)
+}

--- a/microservices/audio_processor/setup.sh
+++ b/microservices/audio_processor/setup.sh
@@ -1,0 +1,3 @@
+openssl rand -base64 756 > ${PWD}/rs_keyfile
+chmod 0400 ${PWD}/rs_keyfile
+chown 999:999 ${PWD}/rs_keyfile


### PR DESCRIPTION
### Descripción de los cambios:

- Se refactorizó el manejador de salud (`HealthHandler`) para incluir verificaciones de servicios específicas según el entorno (local o AWS).
- Se agregó una función `getServiceChecks` que determina qué servicios verificar dependiendo de la configuración del entorno.
- Se mejoró la validación de hosts para requerir al menos un host no vacío.
- Se actualizó el archivo `setup.sh` para generar y configurar el archivo de clave del replica set de MongoDB.
- Se modificó la configuración de Docker Compose para MongoDB para habilitar el modo de replica set, ajustar los comandos de salud y montar el archivo de clave del sistema de archivos.
- Se ajustaron los comandos de salud para garantizar que el replica set esté inicializado correctamente.
