### PR TITLE
fix: Implement proper MongoDB replica set initialization and authentication sequence

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,8 +14,12 @@ resources:
   - stateful/mongodb/mongo-persistentvolume.yaml
   - stateful/mongodb/service.yaml
   - stateful/mongodb/statefulset.yaml
+  - stateful/mongodb/mongodb-job-init.yaml
+  - stateful/mongodb/mongodb-auth-enable.yaml
+
 
   # Backend services
   - backend/configmap.yaml
   - backend/service.yaml
   - backend/deployment.yaml
+  - backend/ingress.yaml

--- a/k8s/base/stateful/mongodb/mongodb-auth-enable.yaml
+++ b/k8s/base/stateful/mongodb/mongodb-auth-enable.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongo-auth-enable
+spec:
+  template:
+    spec:
+      containers:
+      - name: mongo-auth-enable
+        image: mongo:8
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Habilitando autenticacion..."
+          mongosh --host mongo-0.mongodb-service-cluster:27017 -u ${MONGO_INITDB_ROOT_USERNAME} -p ${MONGO_INITDB_ROOT_PASSWORD} --authenticationDatabase admin <<EOF
+          use admin;
+          db.adminCommand({ setParameter: 1, authenticationMechanisms: ["SCRAM-SHA-1", "SCRAM-SHA-256"] });
+          EOF
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-secrets
+              key: MONGO_USER
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-secrets
+              key: MONGO_PASSWORD
+      restartPolicy: OnFailure

--- a/k8s/base/stateful/mongodb/mongodb-job-init.yaml
+++ b/k8s/base/stateful/mongodb/mongodb-job-init.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongo-rs-init
+spec:
+  template:
+    spec:
+      containers:
+      - name: mongo-rs-init
+        image: mongo:8
+        command:
+        - /bin/sh
+        - -c
+        - |
+          wait_for_mongo() {
+            echo "esperamos a que el hijo de puta de mongodb, este disponible..."
+            until mongosh --host mongo-0.mongodb-service-cluster:27017 --eval "print('wait')" 2>/dev/null; do
+              echo "esperando conexión a MongoDB..."
+              sleep 5
+            done
+          }
+
+          wait_for_mongo
+
+          echo "Iniciando replica set..."
+          mongosh --host mongo-0.mongodb-service-cluster:27017 <<EOF
+          try {
+            rs.status();
+          } catch(err) {
+            if(err.codeName === "NotYetInitialized") {
+              rs.initiate({
+                _id: "rs0",
+                members: [
+                  { _id: 0, host: "mongo-0.mongodb-service-cluster:27017", priority: 2 },
+                  { _id: 1, host: "mongo-1.mongodb-service-cluster:27017", priority: 1 },
+                  { _id: 2, host: "mongo-2.mongodb-service-cluster:27017", priority: 1 }
+                ]
+              });
+            }
+          }
+          EOF
+
+          echo "Esperando a que el replica set este listo..."
+          until mongosh --host mongo-0.mongodb-service-cluster:27017 --eval 'rs.status().ok' | grep -q 1; do
+            echo "Esperando que el replica set este listo..."
+            sleep 5
+          done
+
+          echo "Esperando al nodo primario..."
+          until mongosh --host mongo-0.mongodb-service-cluster:27017 --eval 'rs.isMaster().ismaster' | grep -q true; do
+            echo "Esperando al nodo primario..."
+            sleep 5
+          done
+
+          echo "Creando usuario root..."
+          mongosh --host mongo-0.mongodb-service-cluster:27017 <<EOF
+          use admin;
+          try {
+            db.createUser({
+              user: "$MONGO_INITDB_ROOT_USERNAME",
+              pwd: "$MONGO_INITDB_ROOT_PASSWORD",
+              roles: [{ role: "root", db: "admin" }]
+            });
+          } catch(err) {
+            if(err.codeName !== "DuplicateKey") {
+              throw err;
+            }
+          }
+          EOF
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-secrets
+              key: MONGO_USER
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-secrets
+              key: MONGO_PASSWORD
+      restartPolicy: OnFailure

--- a/k8s/base/stateful/mongodb/service.yaml
+++ b/k8s/base/stateful/mongodb/service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: mongodb-service-cluster
 spec:
+  clusterIP: None
   selector:
     app: mongo
   ports:
-    - protocol: TCP
-      port: 27017
+    - port: 27017
       targetPort: 27017
-  type: ClusterIP
+  publishNotReadyAddresses: true

--- a/k8s/base/stateful/mongodb/statefulset.yaml
+++ b/k8s/base/stateful/mongodb/statefulset.yaml
@@ -18,28 +18,17 @@ spec:
         image: mongo:8
         command:
           - mongod
-          - '--bind_ip_all'
-          - '--replSet'
+          - "--replSet"
           - rs0
+          - "--bind_ip_all"
         ports:
         - containerPort: 27017
-        env:
-        - name: MONGO_INITDB_ROOT_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: mongodb-secrets
-              key: MONGO_USER
-        - name: MONGO_INITDB_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mongodb-secrets
-              key: MONGO_PASSWORD
         resources:
           requests:
             memory: "1Gi"
             cpu: "0.5"
         volumeMounts:
-        - name: mongo-data  
+        - name: mongo-data
           mountPath: /data/db
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
# Arreglo de la inicialización del replica set y autenticación de MongoDB en Kubernetes

## Descripción del problema
Cuando desplegamos MongoDB en el cluster de Kubernetes usando StatefulSet, nos topamos con varios problemas de autenticación:

1. Loop inicial de autenticación:
   - El StatefulSet arrancaba con la autenticación habilitada (usando keyFile)
   - El job de inicialización no podía crear el usuario root porque necesitaba autenticación
   - Era un círculo vicioso: necesitábamos auth para crear el usuario, pero necesitábamos el usuario para la auth

2. Problemas con el replica set:
   - MongoDB necesitaba que el replica set esté inicializado antes de crear usuarios
   - Había problemas de red/DNS que no dejaban que los nodos se comuniquen bien
   - Los pods no esperaban lo suficiente a que la red esté lista

## Solución

### 1. Modificamos la config del StatefulSet
- Sacamos el requerimiento inicial de autenticación con keyFile
- Dejamos que los pods arranquen sin autenticación obligatoria
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: mongo
spec:
  # ... otras configs ...
  template:
    spec:
      containers:
      - name: mongo
        command:
          - mongod
          - "--replSet"
          - rs0
          - "--bind_ip_all"
```

### 2. Mejoramos la config del Service
- Pusimos un servicio headless para que la resolución DNS del StatefulSet funcione mejor
- Agregamos `publishNotReadyAddresses` para que la inicialización del replica set no falle
```yaml
apiVersion: v1
kind: Service
metadata:
  name: mongodb-service-cluster
spec:
  clusterIP: None
  selector:
    app: mongo
  ports:
    - port: 27017
      targetPort: 27017
  publishNotReadyAddresses: true
```

### 3. Mejoramos el Job de inicialización
Creamos un job más robusto que:
1. Espera a que la red esté disponible
2. Inicializa el replica set
3. Espera a que se elija el nodo primario
4. Crea el usuario root
5. Habilita la autenticación

Las mejoras principales en el job:
```yaml
spec:
  template:
    spec:
      containers:
      - name: mongo-rs-init
        command:
        - /bin/sh
        - -c
        - |
          # Espera a que MongoDB esté disponible
          wait_for_mongo()
          
          # Inicializa el replica set con los checks necesarios
          # Crea el usuario root cuando el primario está listo
          # Habilita la autenticación
```

## Cómo verificar que funcione
1. Desplegá el StatefulSet:
```bash
kubectl apply -k .
```

2. Mirá los logs del job de inicialización:
```bash
kubectl logs -f job/mongo-rs-init
```

3. Verificá que podés conectarte:
```bash
kubectl exec -it mongo-0 -- mongosh -u root -p root
```