### PR TITLE
Add DynamoDB tables with outputs, variables, and global secondary indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /microservices/audio_processor/credentials_aws.env
 /microservices/audio_processor/test_local.env
 /microservices/audio_processor/rs_keyfile
+/microservices/audio_processor/song-downloader-infra/.terraform/
+/microservices/audio_processor/song-downloader-infra/.terraform.lock.hcl

--- a/microservices/audio_processor/song-downloader-infra/modules/database/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/database/main.tf
@@ -1,0 +1,83 @@
+resource "aws_dynamodb_table" "songs" {
+  name = "${var.project_name}-songs-${var.environment}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key       = "PK"
+  range_key      = "SK"
+  
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  attribute {
+    name = "title"
+    type = "S"
+  }
+
+  attribute {
+    name = "url_youtube"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name = "GSI2-title-index"
+    hash_key = "title"
+    projection_type = "ALL"
+    read_capacity = 5
+    write_capacity = 5
+  }
+
+  global_secondary_index {
+    name = "GSI1-url-youtube-index"
+    hash_key = "url_youtube"
+    projection_type = "ALL"
+    read_capacity = 5
+    write_capacity = 5
+  }
+
+  tags = {
+    Environment = var.environment
+    Project = var.project_name
+  }
+}
+
+resource "aws_dynamodb_table" "operations" {
+  name = "${var.project_name}-operations-${var.environment}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key       = "PK"
+  range_key      = "SK"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SongID"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name = "SongIDIndex"
+    hash_key = "SongID"
+    projection_type = "ALL"
+    read_capacity = 5
+    write_capacity = 5
+  }
+
+  tags = {
+    Environment = var.environment
+    Project = var.project_name
+  }
+}

--- a/microservices/audio_processor/song-downloader-infra/modules/database/outputs.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/database/outputs.tf
@@ -1,0 +1,17 @@
+output "songs_table_name" {
+  description = "Nombre de la tabla de canciones"
+  value = aws_dynamodb_table.songs.name
+}
+
+output "operations_table_name" {
+  description = "Nombre de la tabla de operaciones"
+  value = aws_dynamodb_table.operations.name
+}
+
+output "table_arns" {
+  description = "ARNs de las tablas DynamoDB"
+  value = [
+    aws_dynamodb_table.songs.arn,
+    aws_dynamodb_table.operations.arn
+  ]
+}

--- a/microservices/audio_processor/song-downloader-infra/modules/database/variables.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/database/variables.tf
@@ -1,0 +1,9 @@
+variable "project_name" {
+  description = "Nombre del proyecto"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue"
+  type        = string
+}


### PR DESCRIPTION
### Descripción

Este pull request agrega la infraestructura necesaria en Terraform para manejar las tablas de DynamoDB en el proyecto, incluyendo configuraciones clave para el despliegue en diferentes entornos.

### Cambios principales

- **Tablas DynamoDB:** Se crearon las tablas `songs` y `operations` con configuraciones de `PAY_PER_REQUEST` y atributos clave como `PK` y `SK`.
- **Índices secundarios globales:** Se agregaron índices secundarios globales (`GSI`) para los atributos `title`, `url_youtube` en `songs` y `SongID` en `operations`, optimizando las consultas.
- **Outputs:** Se añadieron outputs para el nombre y el ARN de cada tabla, facilitando su acceso en otros módulos de Terraform.
- **Variables:** Se incorporaron variables `project_name` y `environment`, permitiendo que los nombres de recursos sean dinámicos según el proyecto y el ambiente de despliegue.
