### PR TITLE
Add variables for project name, environment, tags, and VPC ID

### DIFF
--- a/microservices/audio_processor/song-downloader-infra/modules/security_group_alb/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/security_group_alb/main.tf
@@ -1,0 +1,19 @@
+resource "aws_security_group" "alb" {
+  name = "${var.project_name}-${var.environment}-alb-sg"
+  description = "Security group para el ALB"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"]
+    description = "Permitir el trafico HTTP desde la IP del usuario"
+  }
+
+  tags = var.tags
+}
+
+data "http" "myip" {
+  url = "https://ipv4.icanhazip.com"
+}

--- a/microservices/audio_processor/song-downloader-infra/modules/security_group_alb/outputs.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/security_group_alb/outputs.tf
@@ -1,0 +1,4 @@
+output "security_group_alb_id" {
+  description = "ID del Security Group de ECS"
+  value       = aws_security_group.alb.id
+}

--- a/microservices/audio_processor/song-downloader-infra/modules/security_group_alb/variables.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/security_group_alb/variables.tf
@@ -1,0 +1,21 @@
+variable "project_name" {
+  description = "Nombre del proyecto"
+  type = string
+  default = "music-downloader"
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue"
+  type = string
+}
+
+variable "tags" {
+  description = "Etiquetas para los recursos"
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_id" {
+  description = "VPC ID donde se crea el Security Group"
+  type        = string
+}


### PR DESCRIPTION
### Descripción

Este pull request agrega las variables necesarias para mejorar la configuración y personalización de los recursos en Terraform. Las variables permiten una mayor flexibilidad al gestionar el nombre del proyecto, el entorno de despliegue, las etiquetas de los recursos y la VPC en la que se crea el security group.

### Cambios principales

- **project_name:** Variable para el nombre del proyecto, con valor por defecto `"music-downloader"`.
- **environment:** Variable para especificar el ambiente de despliegue (por ejemplo, `dev`, `prod`).
- **tags:** Variable para definir etiquetas personalizadas para los recursos. Se asigna un valor vacío por defecto.
- **vpc_id:** Variable para el ID de la VPC donde se crea el security group, permitiendo personalizar la ubicación del recurso en la red.
