### PR TITLE
Add cAdvisor deployment with RBAC, Service, and monitoring configuration

### DIFF
--- a/k8s/cadvisor/clusterrole.yaml
+++ b/k8s/cadvisor/clusterrole.yaml
@@ -1,0 +1,11 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cadvisor
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - cadvisor

--- a/k8s/cadvisor/clusterrolebinding.yaml
+++ b/k8s/cadvisor/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cadvisor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cadvisor
+subjects:
+- kind: ServiceAccount
+  name: cadvisor
+  namespace: monitoring

--- a/k8s/cadvisor/daemonset.yaml
+++ b/k8s/cadvisor/daemonset.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: monitoring
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  selector:
+    matchLabels:
+      name: cadvisor
+  template:
+    metadata:
+      labels:
+        name: cadvisor
+    spec:
+      serviceAccountName: cadvisor
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      containers:
+      - name: cadvisor
+        image: gcr.io/cadvisor/cadvisor:v0.43.0
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 150m
+          limits:
+            memory: 800Mi
+            cpu: 300m
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: disk
+          mountPath: /dev/disk
+          readOnly: true
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      - name: disk
+        hostPath:
+          path: /dev/disk

--- a/k8s/cadvisor/sa.yaml
+++ b/k8s/cadvisor/sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cadvisor
+  namespace: monitoring

--- a/k8s/cadvisor/service-monitor.yaml
+++ b/k8s/cadvisor/service-monitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cadvisor
+  namespace: monitoring
+  labels:
+    prometheus: default
+spec:
+  selector:
+    matchLabels:
+      name: cadvisor
+  endpoints:
+  - port: metrics
+    scrapeTimeout: 25s

--- a/k8s/cadvisor/service.yaml
+++ b/k8s/cadvisor/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cadvisor
+  namespace: monitoring
+  labels:
+    name: cadvisor
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: metrics
+  selector:
+    name: cadvisor


### PR DESCRIPTION
# Descripción

Este PR introduce los recursos necesarios para desplegar y monitorear **cAdvisor** en el clúster de Kubernetes, incluyendo:

1. **Configuración RBAC**:
   - Creación de un `ClusterRole` y un `ClusterRoleBinding` para asignar permisos a cAdvisor.
   - Creación de un `ServiceAccount` para un acceso seguro.

2. **DaemonSet**:
   - Despliegue de cAdvisor en todos los nodos del clúster.
   - Configuración de requests y limits de recursos para garantizar un funcionamiento eficiente.
   - Montaje de los paths necesarios del host para la recolección de métricas (e.g., `/rootfs`, `/sys`, `/var/run`).

3. **Service**:
   - Exposición de las métricas de cAdvisor en el puerto 8080 mediante un `Service` tipo `ClusterIP`.

4. **ServiceMonitor**:
   - Configuración para integrar cAdvisor con Prometheus, permitiendo la recolección de métricas de rendimiento y uso de recursos en tiempo real.