### PR TITLE
Add cert-manager namespace with monitoring label

### DIFF
--- a/k8s/cert-manager/helm-values.yaml
+++ b/k8s/cert-manager/helm-values.yaml
@@ -1,0 +1,7 @@
+---
+installCRDs: true
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+    prometheusInstance: default

--- a/k8s/cert-manager/namespace.yaml
+++ b/k8s/cert-manager/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    monitoring: prometheus


### PR DESCRIPTION
# Descripción  

Este PR introduce un **Namespace** llamado `cert-manager` con la siguiente configuración:  

1. **Creación del Namespace**:  
   - Se agrega un nuevo Namespace llamado `cert-manager` para organizar recursos relacionados con la gestión de certificados.  

2. **Etiqueta para monitoreo**:  
   - Se incluye la etiqueta `monitoring: prometheus`, permitiendo la integración con sistemas de monitoreo como Prometheus.  

# Motivación  

Este cambio prepara el entorno para implementar recursos relacionados con `cert-manager` y asegura que puedan ser monitoreados adecuadamente mediante herramientas como Prometheus.  
