### PR TITLE
Deploy MongoDB Cluster with TLS, Authentication, and Monitoring Integration

### DIFF
--- a/k8s/mongodb/certificates/ca-issuer.yaml
+++ b/k8s/mongodb/certificates/ca-issuer.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-ca
+spec:
+  ca:
+    secretName: cluster-ca-key-pair

--- a/k8s/mongodb/certificates/ca.yaml
+++ b/k8s/mongodb/certificates/ca.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  duration: 43800h
+  commonName: cluster-ca.io
+  secretName: cluster-ca-key-pair
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/k8s/mongodb/certificates/self-signed-issuer.yaml
+++ b/k8s/mongodb/certificates/self-signed-issuer.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}

--- a/k8s/mongodb/crd.yaml
+++ b/k8s/mongodb/crd.yaml
@@ -1,0 +1,353 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: mongodbcommunity.mongodbcommunity.mongodb.com
+spec:
+  group: mongodbcommunity.mongodb.com
+  names:
+    kind: MongoDBCommunity
+    listKind: MongoDBCommunityList
+    plural: mongodbcommunity
+    shortNames:
+    - mdbc
+    singular: mongodbcommunity
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Current state of the MongoDB deployment
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Version of MongoDB server
+      jsonPath: .status.version
+      name: Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: MongoDBCommunity is the Schema for the mongodbs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MongoDBCommunitySpec defines the desired state of MongoDB
+            properties:
+              additionalMongodConfig:
+                description: 'AdditionalMongodConfig is additional configuration that
+                  can be passed to each data-bearing mongod at runtime. Uses the same
+                  structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              arbiters:
+                description: Arbiters is the number of arbiters (each counted as a
+                  member) in the replica set
+                type: integer
+              featureCompatibilityVersion:
+                description: FeatureCompatibilityVersion configures the feature compatibility
+                  version that will be set for the deployment
+                type: string
+              members:
+                description: Members is the number of members in the replica set
+                type: integer
+              replicaSetHorizons:
+                description: ReplicaSetHorizons Add this parameter and values if you
+                  need your database to be accessed outside of Kubernetes. This setting
+                  allows you to provide different DNS settings within the Kubernetes
+                  cluster and to the Kubernetes cluster. The Kubernetes Operator uses
+                  split horizon DNS for replica set members. This feature allows communication
+                  both within the Kubernetes cluster and from outside Kubernetes.
+                items:
+                  additionalProperties:
+                    type: string
+                  type: object
+                type: array
+              security:
+                description: Security configures security features, such as TLS, and
+                  authentication settings for a deployment
+                properties:
+                  authentication:
+                    properties:
+                      ignoreUnknownUsers:
+                        default: true
+                        nullable: true
+                        type: boolean
+                      modes:
+                        description: Modes is an array specifying which authentication
+                          methods should be enabled.
+                        items:
+                          enum:
+                          - SCRAM
+                          - SCRAM-SHA-256
+                          - SCRAM-SHA-1
+                          type: string
+                        type: array
+                    required:
+                    - modes
+                    type: object
+                  roles:
+                    description: User-specified custom MongoDB roles that should be
+                      configured in the deployment.
+                    items:
+                      description: CustomRole defines a custom MongoDB role.
+                      properties:
+                        authenticationRestrictions:
+                          description: The authentication restrictions the server
+                            enforces on the role.
+                          items:
+                            description: AuthenticationRestriction specifies a list
+                              of IP addresses and CIDR ranges users are allowed to
+                              connect to or from.
+                            properties:
+                              clientSource:
+                                items:
+                                  type: string
+                                type: array
+                              serverAddress:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - clientSource
+                            - serverAddress
+                            type: object
+                          type: array
+                        db:
+                          description: The database of the role.
+                          type: string
+                        privileges:
+                          description: The privileges to grant the role.
+                          items:
+                            description: Privilege defines the actions a role is allowed
+                              to perform on a given resource.
+                            properties:
+                              actions:
+                                items:
+                                  type: string
+                                type: array
+                              resource:
+                                description: Resource specifies specifies the resources
+                                  upon which a privilege permits actions. See https://docs.mongodb.com/manual/reference/resource-document
+                                  for more.
+                                properties:
+                                  anyResource:
+                                    type: boolean
+                                  cluster:
+                                    type: boolean
+                                  collection:
+                                    type: string
+                                  db:
+                                    type: string
+                                type: object
+                            required:
+                            - actions
+                            - resource
+                            type: object
+                          type: array
+                        role:
+                          description: The name of the role.
+                          type: string
+                        roles:
+                          description: An array of roles from which this role inherits
+                            privileges.
+                          items:
+                            description: Role is the database role this user should
+                              have
+                            properties:
+                              db:
+                                description: DB is the database the role can act on
+                                type: string
+                              name:
+                                description: Name is the name of the role
+                                type: string
+                            required:
+                            - db
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - db
+                      - privileges
+                      - role
+                      type: object
+                    type: array
+                  tls:
+                    description: TLS configuration for both client-server and server-server
+                      communication
+                    properties:
+                      caCertificateSecretRef:
+                        description: CaCertificateSecret is a reference to a Secret
+                          containing the certificate for the CA which signed the server
+                          certificates The certificate is expected to be available
+                          under the key "ca.crt"
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      caConfigMapRef:
+                        description: CaConfigMap is a reference to a ConfigMap containing
+                          the certificate for the CA which signed the server certificates
+                          The certificate is expected to be available under the key
+                          "ca.crt" This field is ignored when CaCertificateSecretRef
+                          is configured
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      certificateKeySecretRef:
+                        description: CertificateKeySecret is a reference to a Secret
+                          containing a private key and certificate to use for TLS.
+                          The key and cert are expected to be PEM encoded and available
+                          at "tls.key" and "tls.crt". This is the same format used
+                          for the standard "kubernetes.io/tls" Secret type, but no
+                          specific type is required. Alternatively, an entry tls.pem,
+                          containing the concatenation of cert and key, can be provided.
+                          If all of tls.pem, tls.crt and tls.key are present, the
+                          tls.pem one needs to be equal to the concatenation of tls.crt
+                          and tls.key
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      enabled:
+                        type: boolean
+                      optional:
+                        description: Optional configures if TLS should be required
+                          or optional for connections
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              statefulSet:
+                description: StatefulSetConfiguration holds the optional custom StatefulSet
+                  that should be merged into the operator created one.
+                properties:
+                  spec:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - spec
+                type: object
+              type:
+                description: Type defines which type of MongoDB deployment the resource
+                  should create
+                enum:
+                - ReplicaSet
+                type: string
+              users:
+                description: Users specifies the MongoDB users that should be configured
+                  in your deployment
+                items:
+                  properties:
+                    db:
+                      description: DB is the database the user is stored in. Defaults
+                        to "admin"
+                      type: string
+                    name:
+                      description: Name is the username of the user
+                      type: string
+                    passwordSecretRef:
+                      description: PasswordSecretRef is a reference to the secret
+                        containing this user's password
+                      properties:
+                        key:
+                          description: Key is the key in the secret storing this password.
+                            Defaults to "password"
+                          type: string
+                        name:
+                          description: Name is the name of the secret storing this
+                            user's password
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    roles:
+                      description: Roles is an array of roles assigned to this user
+                      items:
+                        description: Role is the database role this user should have
+                        properties:
+                          db:
+                            description: DB is the database the role can act on
+                            type: string
+                          name:
+                            description: Name is the name of the role
+                            type: string
+                        required:
+                        - db
+                        - name
+                        type: object
+                      type: array
+                    scramCredentialsSecretName:
+                      description: ScramCredentialsSecretName appended by string "scram-credentials"
+                        is the name of the secret object created by the mongoDB operator
+                        for storing SCRAM credentials
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  - passwordSecretRef
+                  - roles
+                  - scramCredentialsSecretName
+                  type: object
+                type: array
+              version:
+                description: Version defines which version of MongoDB will be used
+                type: string
+            required:
+            - security
+            - type
+            - users
+            type: object
+          status:
+            description: MongoDBCommunityStatus defines the observed state of MongoDB
+            properties:
+              currentMongoDBMembers:
+                type: integer
+              currentStatefulSetReplicas:
+                type: integer
+              message:
+                type: string
+              mongoUri:
+                type: string
+              phase:
+                type: string
+              version:
+                type: string
+            required:
+            - currentMongoDBMembers
+            - currentStatefulSetReplicas
+            - mongoUri
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/k8s/mongodb/exporter/deployment.yaml
+++ b/k8s/mongodb/exporter/deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb-exporter
+  namespace: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb-exporter
+  template:
+    metadata:
+      labels:
+        app: mongodb-exporter
+    spec:
+      containers:
+      - name: mongodb-exporter
+        image: percona/mongodb_exporter:0.42.0
+        args:
+        - "--mongodb.direct-connect=false"
+        - "--compatible-mode"
+        - "--discovering-mode"
+        - "--collect-all"
+        - "--mongodb.uri=mongodb+srv://admin-user:root@my-mongodb-svc.mongodb.svc.cluster.local/admin?ssl=true&tlsCAFile=/var/lib/tls/ca/ca.crt&tlsCertificateKeyFile=/var/lib/tls/server/certificateKey.pem"
+        ports:
+        - name: metrics
+          containerPort: 9216
+        resources:
+          limits:
+            memory: 512Mi
+            cpu: 500m
+          requests:
+            memory: 128Mi
+            cpu: 250m
+        volumeMounts:
+        - mountPath: /var/lib/tls/ca/
+          name: tls-ca
+          readOnly: true
+        - mountPath: /var/lib/tls/server/certificateKey.pem
+          name: tls-secret
+          subPathExpr: 9b50678c8fb7fa76e22e0232605573cb1812688d38c3bd6378ffdbe6dbe3dd2c.pem
+          readOnly: true
+      volumes:
+      - name: tls-ca
+        secret:
+          defaultMode: 416
+          secretName: mongodb-key-pair
+      - name: tls-secret
+        secret:
+          defaultMode: 416
+          secretName: my-mongodb-server-certificate-key

--- a/k8s/mongodb/exporter/service-monitor.yaml
+++ b/k8s/mongodb/exporter/service-monitor.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mongodb
+  namespace: mongodb
+  labels:
+    prometheus: default
+spec:
+  endpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app: mongodb-exporter

--- a/k8s/mongodb/exporter/service.yaml
+++ b/k8s/mongodb/exporter/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb-exporter
+  namespace: mongodb
+  labels:
+    app: mongodb-exporter
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9216
+  selector:
+    app: mongodb-exporter

--- a/k8s/mongodb/internal/certificate.yaml
+++ b/k8s/mongodb/internal/certificate.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mongodb
+  namespace: mongodb
+spec:
+  isCA: false
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  dnsNames:
+  - my-mongodb-0.my-mongodb-svc.mongodb.svc.cluster.local
+  - my-mongodb-1.my-mongodb-svc.mongodb.svc.cluster.local
+  - my-mongodb-2.my-mongodb-svc.mongodb.svc.cluster.local
+  secretName: mongodb-key-pair
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 4096
+  issuerRef:
+    name: cluster-ca
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/k8s/mongodb/internal/mongodb.yaml
+++ b/k8s/mongodb/internal/mongodb.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: my-mongodb
+  namespace: mongodb
+spec:
+  members: 2
+  type: ReplicaSet
+  version: "5.0.5"
+  security:
+    tls:
+      enabled: true
+      certificateKeySecretRef:
+        name: mongodb-key-pair
+      caCertificateSecretRef:
+        name: mongodb-key-pair
+      # optional: true
+    authentication:
+      modes:
+      - SCRAM
+  users:
+  - name: admin-user
+    db: admin
+    passwordSecretRef:
+      name: admin-user-password
+    roles:
+    - name: clusterAdmin
+      db: admin
+    - name: userAdminAnyDatabase
+      db: admin
+    - name: dbOwner  
+      db: admin
+    - name: clusterMonitor
+      db: admin
+    - name: read
+      db: local
+    - name: read
+      db: admin
+    - name: readAnyDatabase
+      db: admin
+    - name: hostManager
+      db: admin
+    - name: enableSharding
+      db: admin
+    scramCredentialsSecretName: my-scram
+  additionalMongodConfig:
+    storage.wiredTiger.engineConfig.journalCompressor: zlib
+  statefulSet:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: mongod
+            resources:
+              limits:
+                cpu: "0.5"
+                memory: 1Gi
+              requests:
+                cpu: 200m
+                memory: 512Mi      
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - my-mongodb
+                topologyKey: "kubernetes.io/hostname"
+      volumeClaimTemplates:
+      - metadata:
+          name: data-volume
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 40G

--- a/k8s/mongodb/internal/secret.yaml
+++ b/k8s/mongodb/internal/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-user-password
+  namespace: mongodb
+type: Opaque
+stringData:
+  password: root

--- a/k8s/mongodb/namespace.yaml
+++ b/k8s/mongodb/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mongodb
+  labels:
+    monitoring: prometheus

--- a/k8s/mongodb/operator.yaml
+++ b/k8s/mongodb/operator.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: mongodb
+  name: mongodb-kubernetes-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mongodb-kubernetes-operator
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: mongodb-kubernetes-operator
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - mongodb-kubernetes-operator
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: mongodb-kubernetes-operator
+        - name: AGENT_IMAGE
+          value: quay.io/mongodb/mongodb-agent:11.0.5.6963-1
+        - name: VERSION_UPGRADE_HOOK_IMAGE
+          value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.3
+        - name: READINESS_PROBE_IMAGE
+          value: quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.6
+        - name: MONGODB_IMAGE
+          value: mongo
+        - name: MONGODB_REPO_URL
+          value: docker.io
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.2
+        imagePullPolicy: Always
+        name: mongodb-kubernetes-operator
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 2000
+      serviceAccountName: mongodb-kubernetes-operator

--- a/k8s/mongodb/rbac/role-binding.yaml
+++ b/k8s/mongodb/rbac/role-binding.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator
+  namespace: mongodb
+subjects:
+- kind: ServiceAccount
+  name: mongodb-kubernetes-operator
+roleRef:
+  kind: Role
+  name: mongodb-kubernetes-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/mongodb/rbac/role.yaml
+++ b/k8s/mongodb/rbac/role.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mongodb-kubernetes-operator
+  namespace: mongodb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mongodbcommunity.mongodb.com
+  resources:
+  - mongodbcommunity
+  - mongodbcommunity/status
+  - mongodbcommunity/spec
+  - mongodbcommunity/finalizers
+  verbs:
+  - get
+  - patch
+  - list
+  - update
+  - watch

--- a/k8s/mongodb/rbac/role_binding_database.yaml
+++ b/k8s/mongodb/rbac/role_binding_database.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-database
+  namespace: mongodb
+subjects:
+- kind: ServiceAccount
+  name: mongodb-database
+roleRef:
+  kind: Role
+  name: mongodb-database
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/mongodb/rbac/role_database.yaml
+++ b/k8s/mongodb/rbac/role_database.yaml
@@ -1,0 +1,21 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-database
+  namespace: mongodb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - patch
+  - delete
+  - get

--- a/k8s/mongodb/rbac/service_account.yaml
+++ b/k8s/mongodb/rbac/service_account.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mongodb-kubernetes-operator
+  namespace: mongodb

--- a/k8s/mongodb/rbac/service_account_database.yaml
+++ b/k8s/mongodb/rbac/service_account_database.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mongodb-database
+  namespace: mongodb


### PR DESCRIPTION
## Descripción
Este pull request implementa un clúster de MongoDB en Kubernetes con los siguientes componentes:

1. **MongoDB con TLS y autenticación SCRAM**: Se configura MongoDB con cifrado TLS tanto para la comunicación cliente-servidor como entre nodos del replica set. La autenticación se realiza mediante SCRAM, con usuarios definidos y roles asignados para el control de acceso.
   
2. **MongoDB Kubernetes Operator**: Se despliega el operador de MongoDB para gestionar la creación y mantenimiento del clúster de MongoDB, incluida la gestión de réplicas y configuraciones personalizadas.

3. **Integración con Prometheus para monitoreo**: Se configura el `mongodb-exporter` para exponer métricas a Prometheus, permitiendo el monitoreo de la base de datos. Se incluye un `ServiceMonitor` y un `Service` de Kubernetes para facilitar la recolección de métricas.

4. **Certificados TLS gestionados con Cert-Manager**: Se utiliza `cert-manager` para gestionar certificados y claves, asegurando la autenticidad y seguridad en las conexiones TLS.

5. **Roles y permisos adecuados**: Se definen `Role` y `RoleBinding` para otorgar permisos a los servicios y operadores necesarios en el clúster, permitiendo la creación, modificación y gestión de recursos como pods, secretos y configuraciones.

6. **Persistent Storage**: Se configuran volúmenes persistentes para los datos de MongoDB, garantizando la persistencia de la información a través de los reinicios de pods.

## Cambios clave:
- Creación de un clúster de MongoDB con configuración de replica set y TLS.
- Despliegue del MongoDB Kubernetes Operator y el `mongodb-exporter` para monitoreo.
- Implementación de un certificado TLS gestionado por `cert-manager`.
- Roles y permisos adecuados con `Role` y `RoleBinding` para la gestión del clúster.
- Configuración de persistencia con volúmenes en Kubernetes.