### PR TITLE
Implement Discord presence updates with Observer pattern

### DIFF
--- a/microservices/butakero_bot/internal/domain/ports/observer.go
+++ b/microservices/butakero_bot/internal/domain/ports/observer.go
@@ -1,0 +1,32 @@
+package ports
+
+import "github.com/bwmarrin/discordgo"
+
+type (
+	// VoicePresenceObserver es una interfaz para los observadores que quieren recibir actualizaciones
+	// sobre el estado de los canales de voz. Cualquier tipo que implemente esta interfaz podrá
+	// recibir notificaciones cuando haya cambios en la presencia de los usuarios en los canales de voz.
+	VoicePresenceObserver interface {
+		// UpdatePresence es el método que será llamado por el sujeto para notificar al observador
+		// sobre un cambio en el estado del canal de voz.
+		UpdatePresence(voiceState *discordgo.VoiceStateUpdate)
+	}
+
+	// PresenceSubject es una interfaz para los objetos que mantienen una lista de observadores y les avisan
+	// sobre los cambios en su estado. Un sujeto puede agregar, quitar y notificar a los observadores
+	// registrados.
+	PresenceSubject interface {
+		// AddObserver agrega un nuevo observador a la lista del sujeto. Los observadores registrados
+		// recibirán notificaciones sobre los cambios en el estado del sujeto.
+		AddObserver(observer VoicePresenceObserver)
+
+		// RemoveObserver elimina un observador de la lista del sujeto. Después de eliminarlo, el sujeto
+		// no notificará más a este observador sobre los cambios.
+		RemoveObserver(observer VoicePresenceObserver)
+
+		// NotifyAll avisa a todos los observadores registrados sobre un cambio en el estado
+		// del sujeto. Los observadores recibirán un objeto de tipo *discordgo.VoiceStateUpdate con la
+		// información actualizada sobre el estado del canal de voz.
+		NotifyAll(vs *discordgo.VoiceStateUpdate)
+	}
+)

--- a/microservices/butakero_bot/internal/infrastructure/discord/presence_notifier.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/presence_notifier.go
@@ -1,0 +1,43 @@
+package discord
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/bwmarrin/discordgo"
+	"sync"
+)
+
+type DiscordPresenceNotifier struct {
+	observers []ports.VoicePresenceObserver
+	mu        sync.RWMutex
+}
+
+func NewDiscordPresenceNotifier() *DiscordPresenceNotifier {
+	return &DiscordPresenceNotifier{
+		observers: make([]ports.VoicePresenceObserver, 0),
+	}
+}
+
+func (n *DiscordPresenceNotifier) AddObserver(o ports.VoicePresenceObserver) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.observers = append(n.observers, o)
+}
+
+func (n *DiscordPresenceNotifier) RemoveObserver(o ports.VoicePresenceObserver) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for i, observer := range n.observers {
+		if observer == o {
+			n.observers = append(n.observers[:i], n.observers[i+1:]...)
+			break
+		}
+	}
+}
+
+func (n *DiscordPresenceNotifier) NotifyAll(vs *discordgo.VoiceStateUpdate) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	for _, observer := range n.observers {
+		observer.UpdatePresence(vs)
+	}
+}


### PR DESCRIPTION
- **Created `observer.go`:** Defines interfaces `VoicePresenceObserver` and `PresenceSubject` for implementing the Observer pattern to manage Discord presence updates.  This promotes loose coupling and allows for easier extension.
- **Created `presence_notifier.go`:** Implements a `DiscordPresenceNotifier` struct that conforms to the `PresenceSubject` interface. This struct handles registering, removing, and notifying observers about presence changes.
- **Implemented Observer Pattern:** Uses the newly created interfaces and struct to manage Discord presence updates efficiently, decoupling the notification mechanism from the core logic. This improves maintainability and scalability.