### PR TITLE
feat: Add song download functionality

### DIFF
--- a/microservices/butakero_bot/internal/domain/entity/download_response.go
+++ b/microservices/butakero_bot/internal/domain/entity/download_response.go
@@ -1,0 +1,7 @@
+package entity
+
+type DownloadResponse struct {
+	OperationID string `json:"operation_id"`
+	SongID      string `json:"song_id"`
+	Status      string `json:"status"`
+}

--- a/microservices/butakero_bot/internal/domain/ports/song_downloader.go
+++ b/microservices/butakero_bot/internal/domain/ports/song_downloader.go
@@ -1,0 +1,10 @@
+package ports
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+)
+
+type SongDownloader interface {
+	DownloadSong(ctx context.Context, songName string) (*entity.DownloadResponse, error)
+}

--- a/microservices/butakero_bot/internal/infrastructure/client/audio_api_client.go
+++ b/microservices/butakero_bot/internal/infrastructure/client/audio_api_client.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"go.uber.org/zap"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var (
+	ErrEmptySongName  = errors.New("el nombre de la canción no puede estar vacío")
+	ErrInvalidBaseURL = errors.New("la URL base no es válida")
+)
+
+type AudioAPIClientConfig struct {
+	BaseURL         string
+	Timeout         time.Duration
+	MaxIdleConns    int
+	MaxConnsPerHost int
+}
+
+type AudioAPIClient struct {
+	baseURL    *url.URL
+	logger     logging.Logger
+	httpClient *http.Client
+}
+
+func NewAudioAPIClient(config AudioAPIClientConfig, logger logging.Logger) (*AudioAPIClient, error) {
+	if config.Timeout == 0 {
+		config.Timeout = 10 * time.Second
+	}
+
+	baseURL, err := url.Parse(config.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidBaseURL, err)
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:    config.MaxIdleConns,
+		MaxConnsPerHost: config.MaxConnsPerHost,
+		IdleConnTimeout: 90 * time.Second,
+	}
+
+	return &AudioAPIClient{
+		baseURL: baseURL,
+		logger:  logger,
+		httpClient: &http.Client{
+			Timeout:   config.Timeout,
+			Transport: transport,
+		},
+	}, nil
+}
+
+func (c *AudioAPIClient) DownloadSong(ctx context.Context, songName string) (*entity.DownloadResponse, error) {
+	if songName == "" {
+		return nil, ErrEmptySongName
+	}
+
+	endpoint := c.baseURL.JoinPath("api/v1/audio/start")
+
+	params := url.Values{}
+	params.Add("song", songName)
+	endpoint.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("hubo un error al crear la request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("falló la request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			c.logger.Error("No se pudo cerrar el body de la respuesta",
+				zap.Error(closeErr),
+				zap.String("songName", songName))
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("el código de estado %d no es el esperado, debería ser %d",
+			resp.StatusCode, http.StatusOK)
+	}
+
+	var response entity.DownloadResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("no se pudo decodificar la respuesta: %w", err)
+	}
+
+	c.logger.Info("Iniciando descarga",
+		zap.String("songName", songName),
+		zap.String("operationId", response.OperationID),
+		zap.String("songId", response.SongID))
+
+	return &response, nil
+}

--- a/microservices/butakero_bot/internal/infrastructure/client/audio_api_client_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/client/audio_api_client_test.go
@@ -1,0 +1,138 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestNewAudioAPIClient_ValidConfig(t *testing.T) {
+	mockLogger := new(logging.MockLogger)
+	config := AudioAPIClientConfig{
+		BaseURL:         "http://valid-url.com",
+		Timeout:         5 * time.Second,
+		MaxIdleConns:    10,
+		MaxConnsPerHost: 20,
+	}
+
+	client, err := NewAudioAPIClient(config, mockLogger)
+
+	require.NoError(t, err)
+	assert.NotNil(t, client.httpClient)
+	assert.Equal(t, 5*time.Second, client.httpClient.Timeout)
+}
+
+func TestNewAudioAPIClient_InvalidBaseURL(t *testing.T) {
+	// Arrange
+	loggerMock := new(logging.MockLogger)
+	invalidConfig := AudioAPIClientConfig{
+		BaseURL: ":invalid-url",
+	}
+
+	// Act
+	client, err := NewAudioAPIClient(invalidConfig, loggerMock)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ErrInvalidBaseURL.Error())
+	assert.Nil(t, client)
+}
+
+func TestDownloadSong_EmptySongName(t *testing.T) {
+	loggerMock := new(logging.MockLogger)
+	client := &AudioAPIClient{logger: loggerMock}
+
+	_, err := client.DownloadSong(context.Background(), "")
+
+	assert.Equal(t, ErrEmptySongName, err)
+}
+
+func TestDownloadSong_HTTPError(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer testServer.Close()
+
+	mockLogger := new(logging.MockLogger)
+
+	baseURL, _ := url.Parse(testServer.URL)
+	client := &AudioAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: &http.Client{Timeout: time.Nanosecond},
+	}
+
+	_, err := client.DownloadSong(context.Background(), "test-song")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "falló la request")
+}
+
+func TestDownloadSong_NonOKStatus(t *testing.T) {
+	// Arrange
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer testServer.Close()
+
+	mockLogger := new(logging.MockLogger)
+
+	baseURL, _ := url.Parse(testServer.URL)
+	client := &AudioAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: &http.Client{},
+	}
+
+	// Act
+	_, err := client.DownloadSong(context.Background(), "test-song")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "código de estado 500")
+}
+
+func TestDownloadSong_Success(t *testing.T) {
+	// Arrange
+	expectedResponse := entity.DownloadResponse{
+		OperationID: "123",
+		SongID:      "abc",
+		Status:      "processing",
+	}
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(expectedResponse)
+	}))
+	defer testServer.Close()
+
+	baseURL, _ := url.Parse(testServer.URL)
+	loggerMock := new(logging.MockLogger)
+	loggerMock.On("Info", "Iniciando descarga", []zap.Field{
+		zap.String("songName", "test-song"),
+		zap.String("operationId", "123"),
+		zap.String("songId", "abc"),
+	})
+
+	client := &AudioAPIClient{
+		baseURL:    baseURL,
+		logger:     loggerMock,
+		httpClient: &http.Client{},
+	}
+
+	// Act
+	resp, err := client.DownloadSong(context.Background(), "test-song")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, expectedResponse.OperationID, resp.OperationID)
+	assert.Equal(t, expectedResponse.SongID, resp.SongID)
+	loggerMock.AssertExpectations(t)
+}


### PR DESCRIPTION
- **New `DownloadResponse` entity:** Defines the structure for responses from the song download API, including operation ID, song ID, and status.  This ensures consistent data handling.
- **`SongDownloader` interface:** Introduces an interface for the song download logic, promoting better decoupling and testability.  This allows for different download implementations in the future.
- **`AudioAPIClient` implementation:** Creates a client for interacting with an external audio API to initiate song downloads.  This handles HTTP requests, response parsing, and error handling for the download process.