### PR TITLE
Add audio service to Butakero bot

### DIFF
--- a/microservices/butakero_bot/internal/application/service/audio_service.go
+++ b/microservices/butakero_bot/internal/application/service/audio_service.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"go.uber.org/zap"
+)
+
+type audioService struct {
+	logger     logging.Logger
+	downloader ports.SongDownloader
+}
+
+func NewAudioService(downloader ports.SongDownloader, logger logging.Logger) ports.ExternalSongService {
+	return &audioService{
+		logger:     logger,
+		downloader: downloader,
+	}
+}
+
+func (s *audioService) RequestDownload(ctx context.Context, songName string) (*entity.DownloadResponse, error) {
+	response, err := s.downloader.DownloadSong(ctx, songName)
+	if err != nil {
+		s.logger.Error("Error al solicitar la descarga",
+			zap.String("songName", songName),
+			zap.Error(err))
+		return nil, fmt.Errorf("error al solicitar la descarga: %w", err)
+	}
+
+	s.logger.Info("Solicitud de descarga exitosa",
+		zap.String("songName", songName),
+		zap.String("operationId", response.OperationID))
+
+	return response, nil
+}

--- a/microservices/butakero_bot/internal/application/service/audio_service_test.go
+++ b/microservices/butakero_bot/internal/application/service/audio_service_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"testing"
+)
+
+func TestAudioService_RequestDownload_Success(t *testing.T) {
+	// Arrange
+	mockDownloader := new(MockSongDownloader)
+	loggerMock := new(logging.MockLogger)
+
+	expectedResponse := &entity.DownloadResponse{
+		OperationID: "op123",
+		SongID:      "song456",
+	}
+
+	mockDownloader.On("DownloadSong", mock.Anything, "test-song").Return(expectedResponse, nil)
+	loggerMock.On("Info", "Solicitud de descarga exitosa", []zap.Field{
+		zap.String("songName", "test-song"),
+		zap.String("operationId", "op123"),
+	})
+
+	service := NewAudioService(mockDownloader, loggerMock)
+
+	// Act
+	resp, err := service.RequestDownload(context.Background(), "test-song")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, expectedResponse, resp)
+	mockDownloader.AssertExpectations(t)
+	loggerMock.AssertExpectations(t)
+}
+
+func TestAudioService_RequestDownload_DownloadError(t *testing.T) {
+	// Arrange
+	mockDownloader := new(MockSongDownloader)
+	loggerMock := new(logging.MockLogger)
+
+	expectedError := errors.New("download failed")
+	mockDownloader.On("DownloadSong", mock.Anything, "bad-song").Return(&entity.DownloadResponse{}, expectedError)
+	loggerMock.On("Error", "Error al solicitar la descarga", []zap.Field{
+		zap.String("songName", "bad-song"),
+		zap.Error(expectedError),
+	})
+
+	service := NewAudioService(mockDownloader, loggerMock)
+
+	// Act
+	_, err := service.RequestDownload(context.Background(), "bad-song")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error al solicitar la descarga")
+	assert.Contains(t, err.Error(), expectedError.Error())
+	mockDownloader.AssertExpectations(t)
+	loggerMock.AssertExpectations(t)
+}
+
+func TestAudioService_RequestDownload_LoggingVerification(t *testing.T) {
+	// Arrange
+	mockDownloader := new(MockSongDownloader)
+	loggerMock := new(logging.MockLogger)
+
+	t.Run("error logging parameters", func(t *testing.T) {
+		customError := fmt.Errorf("custom error")
+		mockDownloader.On("DownloadSong", mock.Anything, "specific-song").Return(&entity.DownloadResponse{}, customError)
+		loggerMock.On("Error", "Error al solicitar la descarga", []zap.Field{
+			zap.String("songName", "specific-song"),
+			zap.Error(customError),
+		})
+
+		service := NewAudioService(mockDownloader, loggerMock)
+
+		// Act
+		_, err := service.RequestDownload(context.Background(), "specific-song")
+
+		// Assert
+		assert.Error(t, err)
+		loggerMock.AssertCalled(t, "Error", "Error al solicitar la descarga", []zap.Field{
+			zap.String("songName", "specific-song"),
+			zap.Error(customError),
+		})
+	})
+}

--- a/microservices/butakero_bot/internal/application/service/mocks.go
+++ b/microservices/butakero_bot/internal/application/service/mocks.go
@@ -1,0 +1,16 @@
+package service
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockSongDownloader struct {
+	mock.Mock
+}
+
+func (m *MockSongDownloader) DownloadSong(ctx context.Context, songName string) (*entity.DownloadResponse, error) {
+	args := m.Called(ctx, songName)
+	return args.Get(0).(*entity.DownloadResponse), args.Error(1)
+}

--- a/microservices/butakero_bot/internal/domain/ports/service.go
+++ b/microservices/butakero_bot/internal/domain/ports/service.go
@@ -1,0 +1,13 @@
+package ports
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+)
+
+// ExternalSongService define una interfaz para servicios externos de canciones.
+type ExternalSongService interface {
+	// RequestDownload solicita la descarga de una canción por su nombre o url.
+	// Devuelve una respuesta de descarga o un error si ocurre algún problema.
+	RequestDownload(ctx context.Context, songName string) (*entity.DownloadResponse, error)
+}


### PR DESCRIPTION
- **Added `audio_service.go`:** This file implements the `audioService` struct, which handles song download requests.  It uses a `SongDownloader` port for abstraction and includes robust error handling and logging using `go.uber.org/zap`.
- **Added `audio_service_test.go`:**  Comprehensive unit tests covering successful and failed download scenarios, ensuring the `audioService` functions correctly and logs appropriately.  Mocks are used for dependency injection and testing.
- **Added interface definitions and mock:**  Created `service.go` defining the `ExternalSongService` interface for dependency injection and `mocks.go` providing a mock implementation for testing purposes.