### PR TITLE
Add Media Title to Model and Services

### DIFF
--- a/microservices/audio_processor/internal/domain/model/media.go
+++ b/microservices/audio_processor/internal/domain/model/media.go
@@ -10,8 +10,11 @@ type (
 
 	// Media representa un modelo de procesamiento multimedia.
 	Media struct {
-		ID             string            `json:"id" bson:"_id" dynamodbav:"PK"`
-		VideoID        string            `json:"video_id" bson:"video_id" dynamodbav:"SK"`
+		ID      string `json:"id" bson:"_id" dynamodbav:"PK"`
+		VideoID string `json:"video_id" bson:"video_id" dynamodbav:"SK"`
+		// Title es el título de la canción.
+		// Representa el nombre de la canción tal como aparece en la fuente de origen.
+		Title          string            `json:"title" bson:"title" dynamodbav:"title"`
 		Status         string            `json:"status" bson:"status" dynamodbav:"status"`
 		Message        string            `json:"message" bson:"message" dynamodbav:"message"`
 		Metadata       *PlatformMetadata `json:"metadata" bson:"metadata" dynamodbav:"metadata"`
@@ -27,9 +30,6 @@ type (
 
 	// PlatformMetadata representa los metadatos de una plataforma
 	PlatformMetadata struct {
-		// Title es el título de la canción.
-		// Representa el nombre de la canción tal como aparece en la fuente de origen.
-		Title string `json:"title" bson:"title" dynamodbav:"title"`
 		// DurationMs es la duración de la canción en milisegundos.
 		// Representa cuánto tiempo dura la canción desde el inicio hasta el final.
 		DurationMs int64 `json:"duration_ms" bson:"duration_ms" dynamodbav:"duration_ms"`
@@ -84,7 +84,6 @@ func (f *FileData) ToAttributeValue() types.AttributeValue {
 func (m *PlatformMetadata) ToAttributeValue() types.AttributeValue {
 	return &types.AttributeValueMemberM{
 		Value: map[string]types.AttributeValue{
-			"title":         &types.AttributeValueMemberS{Value: m.Title},
 			"duration_ms":   &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", m.DurationMs)},
 			"url":           &types.AttributeValueMemberS{Value: m.URL},
 			"thumbnail_url": &types.AttributeValueMemberS{Value: m.ThumbnailURL},

--- a/microservices/audio_processor/internal/domain/model/message.go
+++ b/microservices/audio_processor/internal/domain/model/message.go
@@ -4,6 +4,7 @@ type (
 	MediaProcessingMessage struct {
 		ID               string            `json:"id"`
 		VideoID          string            `json:"video_id"`
+		Title            string            `json:"title"`
 		FileData         *FileData         `json:"file_data"`
 		PlatformMetadata *PlatformMetadata `json:"platform_metadata"`
 		ReceiptHandle    string            `json:"receipt_handle,omitempty"`

--- a/microservices/audio_processor/internal/domain/service/core_service.go
+++ b/microservices/audio_processor/internal/domain/service/core_service.go
@@ -50,12 +50,11 @@ func (s *CoreService) ProcessMedia(ctx context.Context, operationID string, medi
 	ctx, cancel := context.WithTimeout(ctx, s.cfg.Service.Timeout)
 	defer cancel()
 
-	metadata := s.createMetadata(mediaDetails)
 	attempts := 0
 
 	s.logger.Info("Iniciando procesamiento de audio",
 		zap.String("operation_id", operationID),
-		zap.String("title", metadata.Title),
+		zap.String("title", mediaDetails.Title),
 	)
 
 	var lastError error
@@ -91,10 +90,10 @@ func (s *CoreService) ProcessMedia(ctx context.Context, operationID string, medi
 		media := &model.Media{
 			ID:      operationID,
 			VideoID: mediaDetails.ID,
+			Title:   mediaDetails.Title,
 			Status:  "success",
 			Message: "Procesamiento completado exitosamente",
 			Metadata: &model.PlatformMetadata{
-				Title:        mediaDetails.Title,
 				DurationMs:   mediaDetails.DurationMs,
 				URL:          mediaDetails.URL,
 				ThumbnailURL: mediaDetails.ThumbnailURL,
@@ -111,9 +110,12 @@ func (s *CoreService) ProcessMedia(ctx context.Context, operationID string, medi
 
 		message := &model.MediaProcessingMessage{
 			ID:               media.ID,
+			Title:            media.Title,
 			VideoID:          media.VideoID,
 			FileData:         media.FileData,
 			PlatformMetadata: media.Metadata,
+			Status:           media.Status,
+			Message:          media.Message,
 		}
 
 		if err := s.mediaService.UpdateMedia(ctx, media.ID, media.VideoID, media); err != nil {
@@ -146,14 +148,4 @@ func (s *CoreService) ProcessMedia(ctx context.Context, operationID string, medi
 	}
 
 	return nil
-}
-
-func (s *CoreService) createMetadata(mediaDetails *model.MediaDetails) *model.PlatformMetadata {
-	return &model.PlatformMetadata{
-		Title:        mediaDetails.Title,
-		DurationMs:   mediaDetails.DurationMs,
-		URL:          mediaDetails.URL,
-		ThumbnailURL: mediaDetails.ThumbnailURL,
-		Platform:     mediaDetails.Provider,
-	}
 }

--- a/microservices/audio_processor/internal/domain/service/operation_service.go
+++ b/microservices/audio_processor/internal/domain/service/operation_service.go
@@ -28,8 +28,8 @@ func (s *OperationService) StartOperation(ctx context.Context, videoID string) (
 		ID:      uuid.New().String(),
 		VideoID: videoID,
 		Status:  "starting",
+		Title:   "",
 		Metadata: &model.PlatformMetadata{
-			Title:        "",
 			DurationMs:   0,
 			URL:          "",
 			ThumbnailURL: "",

--- a/microservices/audio_processor/internal/domain/service/operation_service_test.go
+++ b/microservices/audio_processor/internal/domain/service/operation_service_test.go
@@ -26,8 +26,8 @@ func TestOperationService_StartOperation(t *testing.T) {
 		ID:      uuid.New().String(),
 		VideoID: videoID,
 		Status:  "starting",
+		Title:   "",
 		Metadata: &model.PlatformMetadata{
-			Title:        "",
 			DurationMs:   0,
 			URL:          "",
 			ThumbnailURL: "",

--- a/microservices/audio_processor/internal/infrastructure/repository/dynamodb/media_repository.go
+++ b/microservices/audio_processor/internal/infrastructure/repository/dynamodb/media_repository.go
@@ -188,7 +188,7 @@ func (r *MediaRepositoryDynamoDB) UpdateMedia(ctx context.Context, id, videoID s
 		return ErrInvalidVideoID
 	}
 
-	if media.Metadata == nil || media.Metadata.Title == "" || media.Metadata.Platform == "" {
+	if media.Metadata == nil || media.Title == "" || media.Metadata.Platform == "" {
 		log.Error("Metadatos inválidos", zap.Any("metadata", media.Metadata))
 		return ErrInvalidMetadata
 	}

--- a/microservices/audio_processor/internal/infrastructure/repository/dynamodb/media_repository_test.go
+++ b/microservices/audio_processor/internal/infrastructure/repository/dynamodb/media_repository_test.go
@@ -114,10 +114,10 @@ func TestMediaRepositoryDynamoDB_Integration(t *testing.T) {
 	media := &model.Media{
 		ID:      uuid.New().String(),
 		VideoID: "video123",
+		Title:   "Test Song",
 		Status:  "processed",
 		Message: "success",
 		Metadata: &model.PlatformMetadata{
-			Title:        "Test Song",
 			DurationMs:   300000,
 			URL:          "https://youtube.com/watch?v=video123",
 			ThumbnailURL: "https://img.youtube.com/vi/video123/default.jpg",
@@ -146,7 +146,7 @@ func TestMediaRepositoryDynamoDB_Integration(t *testing.T) {
 	assert.Equal(t, media.VideoID, retrievedMedia.VideoID)
 	assert.Equal(t, media.Status, retrievedMedia.Status)
 	assert.Equal(t, media.Message, retrievedMedia.Message)
-	assert.Equal(t, media.Metadata.Title, retrievedMedia.Metadata.Title)
+	assert.Equal(t, media.Title, retrievedMedia.Title)
 	assert.Equal(t, media.Metadata.DurationMs, retrievedMedia.Metadata.DurationMs)
 	assert.Equal(t, media.Metadata.URL, retrievedMedia.Metadata.URL)
 	assert.Equal(t, media.Metadata.ThumbnailURL, retrievedMedia.Metadata.ThumbnailURL)
@@ -209,10 +209,10 @@ func TestMediaRepositoryDynamoDB_SaveMedia_InvalidID(t *testing.T) {
 	media := &model.Media{
 		ID:      "invalid-uuid",
 		VideoID: "video123",
+		Title:   "Test Song",
 		Status:  "processed",
 		Message: "success",
 		Metadata: &model.PlatformMetadata{
-			Title:        "Test Song",
 			DurationMs:   300000,
 			URL:          "https://youtube.com/watch?v=video123",
 			ThumbnailURL: "https://img.youtube.com/vi/video123/default.jpg",
@@ -330,8 +330,8 @@ func TestMediaRepositoryDynamoDB_UpdateMedia_InvalidMetadata(t *testing.T) {
 		VideoID: "video123",
 		Status:  "processed",
 		Message: "success",
+		Title:   "",
 		Metadata: &model.PlatformMetadata{
-			Title:        "",
 			DurationMs:   300000,
 			URL:          "https://youtube.com/watch?v=video123",
 			ThumbnailURL: "https://img.youtube.com/vi/video123/default.jpg",

--- a/microservices/audio_processor/internal/infrastructure/repository/mongodb/media_repository.go
+++ b/microservices/audio_processor/internal/infrastructure/repository/mongodb/media_repository.go
@@ -77,7 +77,7 @@ func (r *MediaRepository) SaveMedia(ctx context.Context, media *model.Media) err
 	now := time.Now()
 	media.CreatedAt = now
 	media.UpdatedAt = now
-	media.Metadata.Title = strings.ToLower(media.Metadata.Title)
+	media.Title = strings.ToLower(media.Title)
 
 	_, err := r.collection.InsertOne(ctx, media)
 	if err != nil {
@@ -190,7 +190,7 @@ func (r *MediaRepository) UpdateMedia(ctx context.Context, id, videoID string, m
 		return ErrInvalidVideoID
 	}
 
-	if media.Metadata == nil || media.Metadata.Title == "" || media.Metadata.Platform == "" {
+	if media.Metadata == nil || media.Title == "" || media.Metadata.Platform == "" {
 		log.Error("Metadatos inválidos", zap.Any("metadata", media.Metadata))
 		return ErrInvalidMetadata
 	}
@@ -209,6 +209,7 @@ func (r *MediaRepository) UpdateMedia(ctx context.Context, id, videoID string, m
 
 	update := bson.D{
 		{Key: "$set", Value: bson.D{
+			{Key: "title", Value: media.Title},
 			{Key: "status", Value: media.Status},
 			{Key: "message", Value: media.Message},
 			{Key: "metadata", Value: media.Metadata},

--- a/microservices/audio_processor/internal/infrastructure/repository/mongodb/media_repository_test.go
+++ b/microservices/audio_processor/internal/infrastructure/repository/mongodb/media_repository_test.go
@@ -51,8 +51,8 @@ func TestMediaRepository_SaveMedia(t *testing.T) {
 		VideoID: "video123",
 		Status:  "processed",
 		Message: "success",
+		Title:   "Test Song",
 		Metadata: &model.PlatformMetadata{
-			Title:        "Test Song",
 			DurationMs:   300000,
 			URL:          "https://youtube.com/watch?v=video123",
 			ThumbnailURL: "https://img.youtube.com/vi/video123/default.jpg",
@@ -81,7 +81,7 @@ func TestMediaRepository_SaveMedia(t *testing.T) {
 	assert.Equal(t, media.VideoID, retrievedMedia.VideoID)
 	assert.Equal(t, media.Status, retrievedMedia.Status)
 	assert.Equal(t, media.Message, retrievedMedia.Message)
-	assert.Equal(t, media.Metadata.Title, retrievedMedia.Metadata.Title)
+	assert.Equal(t, media.Title, retrievedMedia.Title)
 	assert.Equal(t, media.Metadata.DurationMs, retrievedMedia.Metadata.DurationMs)
 	assert.Equal(t, media.Metadata.URL, retrievedMedia.Metadata.URL)
 	assert.Equal(t, media.Metadata.ThumbnailURL, retrievedMedia.Metadata.ThumbnailURL)
@@ -138,8 +138,8 @@ func TestMediaRepository_UpdateMedia(t *testing.T) {
 		VideoID: "video123",
 		Status:  "processed",
 		Message: "success",
+		Title:   "Test Song",
 		Metadata: &model.PlatformMetadata{
-			Title:        "Test Song",
 			DurationMs:   300000,
 			URL:          "https://youtube.com/watch?v=video123",
 			ThumbnailURL: "https://img.youtube.com/vi/video123/default.jpg",
@@ -193,8 +193,8 @@ func TestMediaRepository_DeleteMedia(t *testing.T) {
 		VideoID: "video123",
 		Status:  "processed",
 		Message: "success",
+		Title:   "Test Song",
 		Metadata: &model.PlatformMetadata{
-			Title:        "Test Song",
 			DurationMs:   300000,
 			URL:          "https://youtube.com/watch?v=video123",
 			ThumbnailURL: "https://img.youtube.com/vi/video123/default.jpg",


### PR DESCRIPTION
- **Added `Title` field to `Media` model:** This allows storing the title of the media file, improving data richness and searchability.  The field is added to both the database models and the message queues.
- **Updated services to use and handle the `Title` field:**  The core service and operation service now properly utilize and propagate the title throughout the media processing pipeline.  This ensures consistency in data handling.
- **Updated repositories to handle `Title` field persistence:** The MongoDB and DynamoDB repositories have been modified to correctly persist and retrieve the `Title` field in the database, ensuring data integrity across different storage mechanisms.