### PR TITLE
Automate Docker image building and pushing

### DIFF
--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+DOCKER_HUB_USERNAME="tomasvilte"
+VERSION="1.0.0"
+
+echo "Introduce tu contraseña de Docker Hub:"
+read -s DOCKER_HUB_PASSWORD
+
+echo "Construyendo la imagen para audio_processor..."
+cd microservices/audio_processor
+docker build -t ${DOCKER_HUB_USERNAME}/audio_processor:${VERSION} -f dockerfile.local .
+cd ../..
+
+echo "Construyendo la imagen para bot..."
+cd microservices/butakero_bot
+docker build -t ${DOCKER_HUB_USERNAME}/butakero_bot:${VERSION} -f Dockerfile .
+
+echo "Construyendo la imagen del bot para debug..."
+docker build -t ${DOCKER_HUB_USERNAME}/butakero_bot:${VERSION}-debug -f Dockerfile.debug .
+cd ../..
+
+echo "Verificando las imágenes construidas..."
+docker images | grep ${DOCKER_HUB_USERNAME}
+
+echo "Iniciando sesión en Docker Hub..."
+echo ${DOCKER_HUB_PASSWORD} | docker login -u ${DOCKER_HUB_USERNAME} --password-stdin
+
+echo "Subiendo audio_processor a Docker Hub..."
+docker push ${DOCKER_HUB_USERNAME}/audio_processor:${VERSION}
+
+echo "Subiendo bot a Docker Hub..."
+docker push ${DOCKER_HUB_USERNAME}/butakero_bot:${VERSION}
+
+echo "Subiendo bot debug a Docker Hub..."
+docker push ${DOCKER_HUB_USERNAME}/butakero_bot:${VERSION}-debug
+
+echo "¡Proceso completado!"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,190 @@
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.7.1
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "22181:2181"
+    networks:
+      - test-application
+
+  kafka:
+    image: confluentinc/cp-kafka:7.7.1
+    depends_on:
+      - zookeeper
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,EXTERNAL://localhost:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "echo 'Verificando Kafka' && kafka-broker-api-versions --bootstrap-server localhost:9092" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - test-application
+
+  mongodb:
+    image: mongo:8
+    container_name: mongodb
+    command: [ "bash", "/etc/mongodb/pki/init.sh", "--replSet", "rs0", "--bind_ip_all", "--port", "27017", "--keyFile", "/etc/mongodb/pki/keyfile" ]
+    environment:
+      MONGO_INITDB_DATABASE: audio_service_db
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+      - ${PWD}/init.sh:/etc/mongodb/pki/init.sh
+    networks:
+      - test-application
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'mongodb:27017'}]}) }"| mongosh --port 27017 -u root -p root --authenticationDatabase admin
+      interval: 5s
+      timeout: 15s
+      retries: 7
+      start_period: 15s
+    restart: always
+
+  audio_processor:
+    image: tomasvilte/audio_processor:1.0.0
+    container_name: audio_processor
+    volumes:
+      - ./yt-cookies.txt:/root/yt-cookies.txt
+      - audio_files:/app/data/audio-files
+    depends_on:
+      kafka:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+    environment:
+      ENVIRONMENT: "local"
+      LOCAL_STORAGE_PATH: "/app/data/audio-files"
+      SERVICE_MAX_ATTEMPTS: 5
+      SERVICE_TIMEOUT: 2
+      YOUTUBE_API_KEY: ${YOUTUBE_API_KEY}
+      GIN_MODE: "release"
+      KAFKA_TOPIC: "notifications"
+      KAFKA_BROKERS: "kafka:29092"
+      KAFKA_ENABLE_TLS: false
+      MONGO_USER: "root"
+      MONGO_PASSWORD: "root"
+      MONGO_PORT: 27017
+      MONGO_HOST: "mongodb"
+      MONGO_DATABASE: "audio_service_db"
+      MONGO_COLLECTION_SONGS: "Songs"
+      MONGO_ENABLE_TLS: false
+      MONGO_REPLICA_SET_NAME: "rs0"
+      COOKIES_YOUTUBE: "/root/yt-cookies.txt"
+    ports:
+      - "8080:8080"
+    networks:
+      - test-application
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/api/v1/health" ]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  butakero_bot:
+    image: tomasvilte/butakero_bot:1.0.0
+    container_name: butakero_bot
+    depends_on:
+      kafka:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+      audio_processor:
+        condition: service_healthy
+    volumes:
+      - audio_files:/app/data/audio-files
+    environment:
+      DISCORD_TOKEN: ${DISCORD_TOKEN}
+      KAFKA_BROKERS: "kafka:29092"
+      KAFKA_TLS_ENABLED: false
+      KAFKA_TLS_CA_FILE: ""
+      KAFKA_TLS_CERT_FILE: ""
+      KAFKA_TLS_KEY_FILE: ""
+      MONGO_HOSTS: "mongodb"
+      MONGO_PORT: 27017
+      MONGO_DATABASE: "audio_service_db"
+      MONGO_COLLECTION: "Songs"
+      MONGO_USERNAME: "root"
+      MONGO_PASSWORD: "root"
+      MONGO_AUTH_SOURCE: "admin"
+      MONGO_REPLICA_SET_NAME: "rs0"
+      MONGO_TIMEOUT: "10s"
+      MONGO_TLS_ENABLED: false
+      MONGO_TLS_CA_FILE: ""
+      MONGO_TLS_CERT_FILE: ""
+      MONGO_TLS_KEY_FILE: ""
+      MONGO_DIRECT_CONNECT: true
+      MONGO_RETRY_WRITES: "true"
+      AUDIO_PROCESSOR_URL: "http://audio_processor:8080"
+    networks:
+      - test-application
+    restart: always
+
+#  butakero_bot_debug:
+#    image: tomasvilte/butakero_bot:1.0.0-debug
+#    container_name: butakero_bot_debug
+#    depends_on:
+#      kafka:
+#        condition: service_healthy
+#      mongodb:
+#        condition: service_healthy
+#      audio_processor:
+#        condition: service_healthy
+#    volumes:
+#      - audio_files:/app/data/audio-files
+#    environment:
+#      DISCORD_TOKEN: ${DISCORD_TOKEN}
+#      KAFKA_BROKERS: "kafka:29092"
+#      KAFKA_TLS_ENABLED: false
+#      KAFKA_TLS_CA_FILE: ""
+#      KAFKA_TLS_CERT_FILE: ""
+#      KAFKA_TLS_KEY_FILE: ""
+#      MONGO_HOSTS: "mongodb"
+#      MONGO_PORT: 27017
+#      MONGO_DATABASE: "audio_service_db"
+#      MONGO_COLLECTION: "Songs"
+#      MONGO_USERNAME: "root"
+#      MONGO_PASSWORD: "root"
+#      MONGO_AUTH_SOURCE: "admin"
+#      MONGO_REPLICA_SET_NAME: "rs0"
+#      MONGO_TIMEOUT: "10s"
+#      MONGO_TLS_ENABLED: false
+#      MONGO_TLS_CA_FILE: ""
+#      MONGO_TLS_CERT_FILE: ""
+#      MONGO_TLS_KEY_FILE: ""
+#      MONGO_DIRECT_CONNECT: true
+#      MONGO_RETRY_WRITES: "true"
+#      AUDIO_PROCESSOR_URL: "http://audio_processor:8080"
+#      LOCAL_STORAGE_PATH: "/app/data/audio-files"
+#    ports:
+#      - "40000:40000"
+#    networks:
+#      - test-application
+#    restart: always
+
+volumes:
+  mongo_data:
+  audio_files:
+
+networks:
+  test-application:
+    driver: bridge

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir -p /etc/mongodb/pki
+
+openssl rand -base64 756 > /etc/mongodb/pki/keyfile
+
+chmod 0400 /etc/mongodb/pki/keyfile
+chown 999:999 /etc/mongodb/pki/keyfile
+
+exec docker-entrypoint.sh "$@"

--- a/microservices/audio_processor/dockerfile.local
+++ b/microservices/audio_processor/dockerfile.local
@@ -8,7 +8,7 @@ ARG TARGETARCH
 ARG TARGETOS
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o main cmd/local/main.go
 
-FROM alpine:latest
+FROM alpine:3.21.3
 RUN apk --no-cache add ca-certificates ffmpeg python3 py3-pip curl \
     && python3 -m venv /venv \
     && /venv/bin/pip install --upgrade pip \

--- a/microservices/audio_processor/dockerfile.prod
+++ b/microservices/audio_processor/dockerfile.prod
@@ -8,7 +8,7 @@ ARG TARGETARCH
 ARG TARGETOS
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o main cmd/aws/main.go
 
-FROM alpine:latest
+FROM alpine:3.21.3
 RUN apk --no-cache add ca-certificates ffmpeg python3 py3-pip curl \
     && python3 -m venv /venv \
     && /venv/bin/pip install --upgrade pip \

--- a/microservices/butakero_bot/Dockerfile
+++ b/microservices/butakero_bot/Dockerfile
@@ -1,0 +1,16 @@
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/ cmd/
+COPY internal/ internal/
+ARG TARGETARCH
+ARG TARGETOS
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o main cmd/main.go
+
+FROM alpine:3.21.3
+
+WORKDIR /root/
+COPY --from=builder /app/main .
+
+CMD ["./main"]

--- a/microservices/butakero_bot/Dockerfile.debug
+++ b/microservices/butakero_bot/Dockerfile.debug
@@ -1,0 +1,22 @@
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+COPY cmd/ cmd/
+COPY internal/ internal/
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+RUN go build -gcflags="all=-N -l" -o main cmd/main.go
+
+FROM alpine:3.21.3
+
+WORKDIR /root/
+
+COPY --from=builder /app/main .
+COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+
+EXPOSE 40000
+
+CMD ["dlv", "exec", "./main", "--headless", "--listen=:40000", "--api-version=2", "--log"]

--- a/microservices/butakero_bot/cmd/bot_local/bot.go
+++ b/microservices/butakero_bot/cmd/bot_local/bot.go
@@ -109,16 +109,7 @@ func StartBot() error {
 
 	discordMessenger := discord.NewDiscordMessengerService(discordClient, logger)
 
-	storageAudio, err := local_storage.NewLocalStorage(&config.Config{
-		Storage: config.StorageConfig{
-			LocalConfig: config.LocalConfig{
-				Directory: cfg.Storage.LocalConfig.Directory,
-			},
-		},
-	}, logger)
-	if err != nil {
-		logger.Error("Error al crear storage de audio", zap.Error(err))
-	}
+	storageAudio := local_storage.NewLocalStorage(logger)
 
 	interactionStorage := storage.NewInMemoryInteractionStorage(logger)
 

--- a/microservices/butakero_bot/internal/infrastructure/storage/local/local_storage.go
+++ b/microservices/butakero_bot/internal/infrastructure/storage/local/local_storage.go
@@ -56,6 +56,9 @@ func (s *LocalStorage) GetAudio(ctx context.Context, songPath string) (io.ReadCl
 		logger.Error("Error al abrir archivo local",
 			zap.String("path", fullPath),
 			zap.Error(err))
+		if os.IsNotExist(err) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("error al abrir archivo: %w", err)
 	}
 


### PR DESCRIPTION
- **Created `build_and_push.sh` script:** Automates the process of building and pushing Docker images for `audio_processor` and `butakero_bot` (including a debug version) to Docker Hub.  This simplifies the deployment process.
- **Refactored `LocalStorage` initialization:** Removed dependency on configuration for the `LocalStorage` in the bot, making it simpler and more testable. Improved error handling, specifically for file not found errors.
- **Updated Dockerfiles base image:** Changed the base image in the Dockerfiles to `alpine:3.21.3` for better security and smaller image sizes.  Also added `docker-compose.yaml` for easier local development.