### PR TITLE
Update infrastructure to support private subnets and internal ALB

### DIFF
--- a/microservices/audio_processor/song-downloader-infra/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/main.tf
@@ -27,7 +27,7 @@ module "secret_manager" {
     "DYNAMODB_TABLE_SONGS": module.database.songs_table_name
     "SERVICE_MAX_ATTEMPTS": var.service_max_attempts
     "SERVICE_TIMEOUT": var.service_timeout
-    "AUDIO_PROCESSOR_URL": module.alb.alb_dns_name
+    "AUDIO_PROCESSOR_URL": "http://${module.alb.alb_dns_name}"
   }
   tags = var.sm_tags
   secret_name = var.secret_name
@@ -101,6 +101,7 @@ module "alb" {
   subnet_ids         = module.networking.public_subnet_ids
   tags               = var.alb_tags
   security_group_alb = module.security_groups.security_group_alb_id
+  private_subnet_ids = [module.networking.private_subnet_ids[0], module.networking.private_subnet_ids[1]]
 
   logs_bucket = module.storage.bucket_name
 }

--- a/microservices/audio_processor/song-downloader-infra/modules/alb/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/alb/main.tf
@@ -1,9 +1,9 @@
 resource "aws_lb" "main" {
   name = "${var.project_name}-alb-${var.environment}"
-  internal = false
+  internal = true
   load_balancer_type = "application"
   security_groups = [var.security_group_alb]
-  subnets = var.subnet_ids
+  subnets = var.private_subnet_ids
 
   enable_deletion_protection = false
   preserve_host_header = true
@@ -13,7 +13,7 @@ resource "aws_lb" "main" {
     prefix = "alb/alb-prod"
     enabled = true
   }
-  
+
   tags = var.tags
 }
 
@@ -44,7 +44,7 @@ resource "aws_lb_listener" "main" {
   load_balancer_arn = aws_lb.main.arn
   port = "80"
   protocol = "HTTP"
-  
+
   default_action {
     type = "forward"
     target_group_arn = aws_lb_target_group.main.arn

--- a/microservices/audio_processor/song-downloader-infra/modules/alb/variables.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/alb/variables.tf
@@ -14,7 +14,12 @@ variable "vpc_id" {
 }
 
 variable "subnet_ids" {
-  description = "IDs de las subnets"
+  description = "IDs de las subnets (para compatibilidad)"
+  type = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "IDs de las subnets privadas para el ALB interno"
   type = list(string)
 }
 

--- a/microservices/audio_processor/song-downloader-infra/modules/networking/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/networking/main.tf
@@ -1,9 +1,9 @@
 resource "aws_vpc" "main" {
-    cidr_block = "10.0.0.0/16"
-    enable_dns_hostnames = true
-    enable_dns_support = true
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support = true
 
-    tags = var.tags
+  tags = var.tags
 }
 
 resource "aws_subnet" "public" {
@@ -20,11 +20,48 @@ resource "aws_subnet" "public" {
   }
 }
 
+resource "aws_subnet" "private" {
+  count = 2
+  vpc_id = aws_vpc.main.id
+  cidr_block = "10.0.${count.index + 10}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "${var.project_name}-private-${count.index + 1}-${var.environment}"
+    Environment = var.environment
+    Project = var.project_name
+  }
+}
+
 resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags = {
     Name = "${var.project_name}-igw-${var.environment}"
+    Environment = var.environment
+    Project = var.project_name
+  }
+}
+
+resource "aws_eip" "nat" {
+  count = 1
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.project_name}-eip-nat-${var.environment}"
+    Environment = var.environment
+    Project = var.project_name
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  count = 1
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${var.project_name}-nat-${var.environment}"
     Environment = var.environment
     Project = var.project_name
   }
@@ -44,13 +81,32 @@ resource "aws_route_table" "public" {
   }
 }
 
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[0].id
+  }
+
+  tags = {
+    Name        = "${var.project_name}-rt-private-${var.environment}"
+    Environment = var.environment
+  }
+}
+
 resource "aws_route_table_association" "public" {
   count = 2
   subnet_id = aws_subnet.public[count.index].id
   route_table_id = aws_route_table.public.id
 }
 
-data "aws_availability_zones" "available" {
-    state = "available"
+resource "aws_route_table_association" "private" {
+  count = 2
+  subnet_id = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/microservices/audio_processor/song-downloader-infra/modules/networking/outputs.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/networking/outputs.tf
@@ -7,3 +7,8 @@ output "public_subnet_ids" {
   description = "IDs de las subnets publicas"
   value = aws_subnet.public[*].id
 }
+
+output "private_subnet_ids" {
+  description = "IDs de las subnets privadas"
+  value = aws_subnet.private[*].id
+}

--- a/microservices/audio_processor/song-downloader-infra/modules/security_groups/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/security_groups/main.tf
@@ -19,7 +19,12 @@ resource "aws_security_group" "ecs" {
     description = "Permitir todo el trafico saliente"
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-${var.environment}-ecs-sg"
+    }
+  )
 }
 
 resource "aws_security_group" "alb" {
@@ -31,21 +36,22 @@ resource "aws_security_group" "alb" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"]
-    description = "Permitir el trafico HTTP desde la IP del usuario"
+    cidr_blocks = ["10.0.0.0/16"]
+    description = "Permitir el trafico HTTP desde dentro de la VPC"
   }
-  
+
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-    description = "Permitir todo el trafico saliente"
+    description = "Permitir trafico TCP saliente al puerto 8080"
   }
 
-  tags = var.tags
-}
-
-data "http" "myip" {
-  url = "https://ipv4.icanhazip.com"
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-${var.environment}-alb-sg"
+    }
+  )
 }

--- a/microservices/audio_processor/song-downloader-infra/outputs.tf
+++ b/microservices/audio_processor/song-downloader-infra/outputs.tf
@@ -13,11 +13,6 @@ output "s3_bucket_name" {
   value       = module.storage.bucket_name
 }
 
-output "dns_alb" {
-  description = "DNS Del ALB"
-  value = "https://${module.alb.alb_dns_name}"
-}
-
 output "secret_arn" {
   description = "ARN del secreto en Secrets Manager"
   value       = module.secret_manager.secret_arn
@@ -48,8 +43,12 @@ output "sg_alb_id" {
   description = "ID del security group del ALB"
 }
 
-output "subnet_ids" {
+output "public_subnet_ids" {
   value = module.networking.public_subnet_ids
   description = "Lista de IDs de subnets públicas"
 }
 
+output "private_subnet_ids" {
+  value = module.networking.private_subnet_ids
+    description = "Lista de IDs de subnets privadas"
+}


### PR DESCRIPTION
- **Migrated to a private subnet architecture:**  The infrastructure was updated to use private subnets instead of public ones for the application load balancer (ALB). This enhances security by reducing the application's exposure to the public internet.  The technical impact is a more secure deployment, requiring internal communication between services.

- **Implemented an internal Application Load Balancer (ALB):** The ALB was reconfigured to operate as an internal ALB within the VPC. This further strengthens security, as the ALB is no longer directly accessible from the public internet.  This requires changes to how the ALB is accessed (via its internal DNS name).

- **Updated Secret Manager secret with internal ALB URL:** The URL stored in Secret Manager pointing to the audio processor was updated to use the internal DNS name of the new internal ALB. This ensures consistency and avoids breaking existing functionality that relies on this secret.