### PR TITLE
Automate Docker image building and pushing to ECR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /microservices/butakero_bot/butakero_bot_infra/.terraform/
 /microservices/butakero_bot/butakero_bot_infra/.terraform.lock.hcl
 /yt-cookies.txt
+/microservices/audio_processor/yt-cookies.txt

--- a/microservices/audio_processor/song-downloader-infra/modules/ecr/variables.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/ecr/variables.tf
@@ -13,3 +13,26 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "aws_region" {
+  description = "Región de AWS"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_account_id" {
+  description = "ID de la cuenta de AWS"
+  type        = string
+}
+
+variable "image_tag" {
+  description = "Tag de la imagen Docker"
+  type        = string
+  default     = "latest"
+}
+
+variable "docker_context_path" {
+  description = "Ruta del contexto de Docker para construir la imagen"
+  type        = string
+  default     = "."
+}

--- a/microservices/butakero_bot/butakero_bot_infra/modules/ecr/main.tf
+++ b/microservices/butakero_bot/butakero_bot_infra/modules/ecr/main.tf
@@ -1,5 +1,35 @@
 resource "aws_ecr_repository" "butakero_bot_prod" {
   name = var.repository_name
+  force_delete = true
+  image_tag_mutability = "MUTABLE"
+
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "app" {
+  repository = aws_ecr_repository.butakero_bot_prod.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description = "Mantener las ultimas 30 imagenes"
+      selection = {
+        tagStatus = "any"
+        countType = "imageCountMoreThan"
+        countNumber = 30
+      }
+      action = {
+        type = "expire"
+      }
+    }]
+  })
 }
 
 resource "null_resource" "build_and_push_image" {
@@ -7,8 +37,10 @@ resource "null_resource" "build_and_push_image" {
     command = <<EOT
       cd ..
       aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com
-      docker buildx create --use
-      docker buildx build --platform linux/arm64 --build-arg ENV=bot_aws -t ${aws_ecr_repository.butakero_bot_prod.repository_url}:${var.image_tag} --push ${var.docker_context_path}
+      docker buildx create --use --name mybuilder-butakero
+      docker buildx build --platform linux/arm64 --build-arg ENV=bot_aws -t ${aws_ecr_repository.butakero_bot_prod.repository_url}:${var.image_tag} --push --no-cache ${var.docker_context_path}
+      docker buildx rm mybuilder-butakero || true
+      docker volume ls -q --filter name=buildx_buildkit | xargs -r docker volume rm 2>/dev/null || true
     EOT
   }
 


### PR DESCRIPTION
- **Automated Docker image building and pushing:**  This change replaces the manual process of building and pushing Docker images to Amazon ECR with an automated solution using Terraform. This is achieved by introducing a `null_resource` with a `local-exec` provisioner that uses the AWS CLI and Docker to build and push the images.
- **Improved ECR Configuration:** Added lifecycle policies to ECR repositories to automatically expire old images, thus optimizing storage costs and management.  Image scanning on push is also enabled for enhanced security.
- **Refactored ECR module:** The ECR module is refactored to include variables for AWS region, account ID, image tag, and Docker context path, making it more flexible and reusable across different projects.  This also centralizes ECR configuration.