### PR TITLE
Auto-stop playback when bot is alone in voice channel

### DIFF
--- a/microservices/butakero_bot/internal/infrastructure/inmemory/state_storage.go
+++ b/microservices/butakero_bot/internal/infrastructure/inmemory/state_storage.go
@@ -1,7 +1,6 @@
 package inmemory
 
 import (
-	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
 	"go.uber.org/zap"
@@ -37,21 +36,23 @@ func (s *InmemoryStateStorage) GetCurrentSong() (*entity.PlayedSong, error) {
 
 // SetCurrentSong establece la canción actual que se está reproduciendo.
 func (s *InmemoryStateStorage) SetCurrentSong(song *entity.PlayedSong) error {
-	if song == nil {
-		s.logger.Warn("Intento de establecer una canción nula")
-		return fmt.Errorf("la canción no puede ser nula")
-	}
-
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
 	logger := s.logger.With(
 		zap.String("method", "SetCurrentSong"),
-		zap.String("songTitle", song.DiscordSong.TitleTrack),
 	)
 
+	if song != nil {
+		logger = logger.With(zap.String("songTitle", song.DiscordSong.TitleTrack))
+	}
+
 	s.currentSong = song
-	logger.Info("Canción actual establecida")
+	if song == nil {
+		logger.Info("Canción actual limpiada")
+	} else {
+		logger.Info("Canción actual establecida")
+	}
 	return nil
 }
 


### PR DESCRIPTION
- **Added automatic playback stop:** The bot now automatically stops playback when it's the only user left in the voice channel. This improves user experience by preventing unnecessary playback when no one is listening.
- **Improved error handling and logging:** Enhanced error handling and logging throughout the player module.  This increases the robustness and maintainability of the bot. More informative error messages are logged, making debugging easier.
- **Refactored `Stop()` method:** The `Stop()` method in the player was refactored to cleanly disconnect from the voice channel and clear the playlist, handling errors more gracefully. This improves the reliability of the stop function.