### PR TITLE
refactor: Decouple GuildPlayer logic into smaller components

### DIFF
--- a/microservices/butakero_bot/internal/domain/ports/discord.go
+++ b/microservices/butakero_bot/internal/domain/ports/discord.go
@@ -15,6 +15,8 @@ type (
 		RemoveSong(position int) (*entity.DiscordEntity, error)
 		GetPlaylist() ([]string, error)
 		GetPlayedSong() (*entity.PlayedSong, error)
+		StateStorage() StateStorage
+		JoinVoiceChannel(channelID string) error
 	}
 
 	DiscordMessenger interface {

--- a/microservices/butakero_bot/internal/infrastructure/discord/guild_manager.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/guild_manager.go
@@ -43,12 +43,14 @@ func (g *GuildManager) CreateGuildPlayer(guildID string) (ports.GuildPlayer, err
 	stateStorage := inmemory.NewInmemoryStateStorage(g.logger)
 
 	guildPlayer := player.NewGuildPlayer(
-		voiceChat,
-		songStorage,
-		stateStorage,
-		g.messenger,
-		g.storageAudio,
-		g.logger,
+		player.Config{
+			VoiceSession: voiceChat,
+			SongStorage:  songStorage,
+			StateStorage: stateStorage,
+			Messenger:    g.messenger,
+			StorageAudio: g.storageAudio,
+			Logger:       g.logger,
+		},
 	)
 
 	g.players[guildID] = guildPlayer

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
@@ -1,0 +1,172 @@
+package player
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"go.uber.org/zap"
+)
+
+type PlaybackController struct {
+	voiceSession  ports.VoiceSession
+	storageAudio  ports.StorageAudio
+	stateStorage  ports.StateStorage
+	messenger     ports.DiscordMessenger
+	logger        logging.Logger
+	stateManager  *StateManager
+	currentCancel context.CancelFunc
+	pauseCh       chan struct{}
+	resumeCh      chan struct{}
+	mu            sync.Mutex
+	currentSong   *entity.PlayedSong
+	playMsgID     string
+}
+
+func NewPlaybackController(
+	voiceSession ports.VoiceSession,
+	storageAudio ports.StorageAudio,
+	stateStorage ports.StateStorage,
+	messenger ports.DiscordMessenger,
+	logger logging.Logger,
+) *PlaybackController {
+	return &PlaybackController{
+		voiceSession: voiceSession,
+		storageAudio: storageAudio,
+		stateStorage: stateStorage,
+		messenger:    messenger,
+		logger:       logger,
+		stateManager: NewStateManager(),
+		pauseCh:      make(chan struct{}),
+		resumeCh:     make(chan struct{}),
+	}
+}
+
+func (pc *PlaybackController) Play(ctx context.Context, song *entity.PlayedSong, textChannel string) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.stateManager.GetState() == StatePlaying {
+		return errors.New("already playing")
+	}
+
+	songCtx, cancel := context.WithCancel(ctx)
+	pc.currentCancel = cancel
+	pc.currentSong = song
+	pc.stateManager.SetState(StatePlaying)
+
+	go pc.playSong(songCtx, song, textChannel)
+	return nil
+}
+
+func (pc *PlaybackController) Pause() error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.stateManager.GetState() != StatePlaying {
+		return errors.New("not playing")
+	}
+
+	pc.stateManager.SetState(StatePaused)
+	pc.pauseCh <- struct{}{}
+	return nil
+}
+
+func (pc *PlaybackController) Resume() error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.stateManager.GetState() != StatePaused {
+		return errors.New("not paused")
+	}
+
+	pc.stateManager.SetState(StatePlaying)
+	pc.resumeCh <- struct{}{}
+	return nil
+}
+
+func (pc *PlaybackController) Stop() {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.currentCancel != nil {
+		pc.currentCancel()
+		pc.currentCancel = nil
+	}
+	pc.stateManager.SetState(StateIdle)
+	pc.currentSong = nil
+}
+
+func (pc *PlaybackController) CurrentState() PlayerState {
+	return pc.stateManager.GetState()
+}
+
+func (pc *PlaybackController) GetVoiceSession() ports.VoiceSession {
+	return pc.voiceSession
+}
+
+func (pc *PlaybackController) CurrentSong() *entity.PlayedSong {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.currentSong
+}
+
+func (pc *PlaybackController) playSong(ctx context.Context, song *entity.PlayedSong, textChannel string) {
+	if err := pc.stateStorage.SetCurrentSong(song); err != nil {
+		pc.logger.Error("Error setting current song", zap.Error(err))
+		return
+	}
+
+	// Enviar mensaje de inicio de reproducción
+	msgID, err := pc.messenger.SendPlayStatus(textChannel, song)
+	if err != nil {
+		pc.logger.Error("Error sending play status", zap.Error(err))
+	} else {
+		pc.playMsgID = msgID
+	}
+
+	// Obtener datos de audio
+	audioData, err := pc.storageAudio.GetAudio(ctx, song.DiscordSong.FilePath)
+	if err != nil {
+		pc.logger.Error("Error getting audio data", zap.Error(err))
+		return
+	}
+
+	// Configurar ticker para actualizar estado
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	done := make(chan struct{})
+	startTime := time.Now()
+
+	// Goroutine para actualizar el estado de reproducción
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				pc.mu.Lock()
+				if pc.currentSong != nil {
+					pc.currentSong.Position = time.Since(startTime).Milliseconds()
+					if err := pc.messenger.UpdatePlayStatus(textChannel, pc.playMsgID, pc.currentSong); err != nil {
+						pc.logger.Error("Error updating play status", zap.Error(err))
+					}
+				}
+				pc.mu.Unlock()
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	// Reproducir audio
+	if err := pc.voiceSession.SendAudio(ctx, audioData); err != nil && !errors.Is(err, context.Canceled) {
+		pc.logger.Error("Error sending audio", zap.Error(err))
+	}
+
+	close(done)
+	pc.Stop()
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
@@ -1,0 +1,22 @@
+package player
+
+// PlayerEvent representa eventos que pueden ocurrir en el reproductor
+type PlayerEvent struct {
+	Type    string
+	Payload interface{}
+}
+
+// Event types
+const (
+	EventPlay   = "play"
+	EventPause  = "pause"
+	EventResume = "resume"
+	EventStop   = "stop"
+	EventSkip   = "skip"
+)
+
+// EventPayload contiene datos adicionales para los eventos
+type EventPayload struct {
+	TextChannelID  *string
+	VoiceChannelID *string
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/interfaces.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/interfaces.go
@@ -1,0 +1,26 @@
+package player
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+)
+
+// PlaybackHandler maneja la reproducción de audio
+type PlaybackHandler interface {
+	Play(ctx context.Context, song *entity.PlayedSong, textChannel string) error
+	Pause() error
+	Resume() error
+	Stop()
+	CurrentState() PlayerState
+	GetVoiceSession() ports.VoiceSession
+}
+
+// PlaylistHandler maneja operaciones con la lista de reproducción
+type PlaylistHandler interface {
+	AddSong(song *entity.PlayedSong) error
+	RemoveSong(position int) (*entity.DiscordEntity, error)
+	GetPlaylist() ([]string, error)
+	ClearPlaylist() error
+	GetNextSong() (*entity.PlayedSong, error)
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/playlist_manager.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/playlist_manager.go
@@ -1,0 +1,77 @@
+package player
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/inmemory"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"go.uber.org/zap"
+)
+
+type PlaylistManager struct {
+	songStorage ports.SongStorage
+	logger      logging.Logger
+}
+
+func NewPlaylistManager(songStorage ports.SongStorage, logger logging.Logger) *PlaylistManager {
+	return &PlaylistManager{
+		songStorage: songStorage,
+		logger:      logger,
+	}
+}
+
+func (pm *PlaylistManager) AddSong(song *entity.PlayedSong) error {
+	if err := pm.songStorage.AppendSong(song); err != nil {
+		pm.logger.Error("Error adding song to playlist", zap.Error(err))
+		return fmt.Errorf("error adding song: %w", err)
+	}
+	return nil
+}
+
+func (pm *PlaylistManager) RemoveSong(position int) (*entity.DiscordEntity, error) {
+	song, err := pm.songStorage.RemoveSong(position)
+	if err != nil {
+		pm.logger.Error("Error removing song from playlist", zap.Error(err), zap.Int("position", position))
+		return nil, fmt.Errorf("error removing song: %w", err)
+	}
+	return song.DiscordSong, nil
+}
+
+func (pm *PlaylistManager) GetPlaylist() ([]string, error) {
+	songs, err := pm.songStorage.GetSongs()
+	if err != nil {
+		pm.logger.Error("Error getting playlist", zap.Error(err))
+		return nil, fmt.Errorf("error getting playlist: %w", err)
+	}
+
+	playlist := make([]string, len(songs))
+	for i, song := range songs {
+		playlist[i] = song.DiscordSong.TitleTrack
+	}
+	return playlist, nil
+}
+
+func (pm *PlaylistManager) ClearPlaylist() error {
+	if err := pm.songStorage.ClearPlaylist(); err != nil {
+		pm.logger.Error("Error clearing playlist", zap.Error(err))
+		return fmt.Errorf("error clearing playlist: %w", err)
+	}
+	return nil
+}
+
+func (pm *PlaylistManager) GetNextSong() (*entity.PlayedSong, error) {
+	song, err := pm.songStorage.PopFirstSong()
+	if errors.Is(err, inmemory.ErrNoSongs) {
+		return nil, ErrPlaylistEmpty
+	}
+	if err != nil {
+		pm.logger.Error("Error getting next song", zap.Error(err))
+		return nil, fmt.Errorf("error getting next song: %w", err)
+	}
+	return song, nil
+}
+
+var ErrPlaylistEmpty = errors.New("playlist is empty")

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/state.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/state.go
@@ -1,0 +1,27 @@
+package player
+
+import (
+	"sync"
+)
+
+// StateManager maneja el estado del reproductor
+type StateManager struct {
+	mu    sync.Mutex
+	state PlayerState
+}
+
+func NewStateManager() *StateManager {
+	return &StateManager{state: StateIdle}
+}
+
+func (sm *StateManager) SetState(newState PlayerState) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.state = newState
+}
+
+func (sm *StateManager) GetState() PlayerState {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.state
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/types.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/types.go
@@ -1,0 +1,25 @@
+package player
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+)
+
+// PlayerState representa el estado actual del reproductor
+type PlayerState string
+
+const (
+	StateIdle    PlayerState = "idle"
+	StatePlaying PlayerState = "playing"
+	StatePaused  PlayerState = "paused"
+)
+
+// Config contiene todas las dependencias necesarias para el reproductor
+type Config struct {
+	VoiceSession ports.VoiceSession
+	SongStorage  ports.SongStorage
+	StateStorage ports.StateStorage
+	Messenger    ports.DiscordMessenger
+	StorageAudio ports.StorageAudio
+	Logger       logging.Logger
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/voice_state_service.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/voice_state_service.go
@@ -3,7 +3,6 @@ package discord
 import (
 	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/player"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
 	"github.com/bwmarrin/discordgo"
 	"go.uber.org/zap"
@@ -55,11 +54,13 @@ func (s *VoiceStateService) HandleVoiceStateChange(
 			}
 
 			if usersInCurrentChannel == 0 {
-				if err := guildPlayer.(*player.GuildPlayer).StateStorage().SetVoiceChannel(newChannelID); err != nil {
+				stateStorage := guildPlayer.StateStorage()
+
+				if err := stateStorage.SetVoiceChannel(newChannelID); err != nil {
 					return fmt.Errorf("error al actualizar el canal de voz: %w", err)
 				}
 
-				if err := guildPlayer.(*player.GuildPlayer).Session().JoinVoiceChannel(newChannelID); err != nil {
+				if err := guildPlayer.JoinVoiceChannel(newChannelID); err != nil {
 					return fmt.Errorf("error al mover el bot al nuevo canal: %w", err)
 				}
 


### PR DESCRIPTION
- **Introduces `PlaybackController`:** Encapsulates audio playback logic, managing play/pause/resume/stop states and interactions with `VoiceSession` and `StorageAudio`. This separates playback concerns from the `GuildPlayer`.
- **Introduces `PlaylistManager`:** Manages the song queue, handling add/remove/get operations through the `SongStorage`.  This isolates playlist management from other player functionalities.
- **Modifies `GuildPlayer`:**  Orchestrates the `PlaybackController` and `PlaylistManager`, handling events and managing the overall player lifecycle.  It also restores the initial state when it is started. This makes the `GuildPlayer` more focused on high-level coordination.