### PR TITLE
feat: Implement pause and resume commands for music playback

### DIFF
--- a/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
@@ -120,6 +120,8 @@ func StartBot() error {
 		command.NewListCommand(handler, logger),
 		command.NewRemoveCommand(handler, logger),
 		command.NewPlayingCommand(handler, logger),
+		command.NewPauseCommand(handler, logger),
+		command.NewResumeCommand(handler, logger),
 	}
 
 	eventsHandler.RegisterEventHandlers(discordClient, ctx)

--- a/microservices/butakero_bot/cmd/bot_local/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_local/bot/bot.go
@@ -135,6 +135,8 @@ func StartBot() error {
 		command.NewListCommand(handler, logger),
 		command.NewRemoveCommand(handler, logger),
 		command.NewPlayingCommand(handler, logger),
+		command.NewPauseCommand(handler, logger),
+		command.NewResumeCommand(handler, logger),
 	}
 
 	eventsHandler.RegisterEventHandlers(discordClient, ctx)

--- a/microservices/butakero_bot/internal/domain/ports/discord.go
+++ b/microservices/butakero_bot/internal/domain/ports/discord.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/bwmarrin/discordgo"
 	"io"
 )
 
@@ -10,6 +11,8 @@ type (
 	GuildPlayer interface {
 		Run(ctx context.Context) error
 		Stop() error
+		Pause() error
+		Resume() error
 		SkipSong()
 		AddSong(textChannelID, voiceChannelID *string, playedSong *entity.PlayedSong) error
 		RemoveSong(position int) (*entity.DiscordEntity, error)
@@ -50,5 +53,6 @@ type (
 		LeaveVoiceChannel() error
 		// SendAudio envía audio a través de la sesión de voz.
 		SendAudio(ctx context.Context, reader io.ReadCloser) error
+		GetVoiceConnection() *discordgo.VoiceConnection
 	}
 )

--- a/microservices/butakero_bot/internal/infrastructure/discord/command/pause_command.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/pause_command.go
@@ -1,0 +1,28 @@
+package command
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/bwmarrin/discordgo"
+)
+
+type PauseCommand struct {
+	BaseCommand
+	handler *CommandHandler
+}
+
+func NewPauseCommand(handler *CommandHandler, logger logging.Logger) Command {
+	return &PauseCommand{
+		BaseCommand: BaseCommand{
+			name:        "pause",
+			description: "Pausa la reproduccion actual",
+			logger:      logger,
+		},
+		handler: handler,
+	}
+}
+
+func (p *PauseCommand) Handler() func(session *discordgo.Session, i *discordgo.InteractionCreate) {
+	return func(session *discordgo.Session, i *discordgo.InteractionCreate) {
+		p.handler.PauseSong(session, i)
+	}
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/command/resume_command.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/resume_command.go
@@ -1,0 +1,28 @@
+package command
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/bwmarrin/discordgo"
+)
+
+type ResumeCommand struct {
+	BaseCommand
+	handler *CommandHandler
+}
+
+func NewResumeCommand(handler *CommandHandler, logger logging.Logger) Command {
+	return &ResumeCommand{
+		BaseCommand: BaseCommand{
+			name:        "resume",
+			description: "Reanudar la cancion actual",
+			logger:      logger,
+		},
+		handler: handler,
+	}
+}
+
+func (r *ResumeCommand) Handler() func(session *discordgo.Session, i *discordgo.InteractionCreate) {
+	return func(session *discordgo.Session, i *discordgo.InteractionCreate) {
+		r.handler.ResumeSong(session, i)
+	}
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/voice/voice_session.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/voice/voice_session.go
@@ -90,3 +90,7 @@ func (d *DiscordVoiceSession) LeaveVoiceChannel() error {
 	}
 	return nil
 }
+
+func (d *DiscordVoiceSession) GetVoiceConnection() *discordgo.VoiceConnection {
+	return d.vc
+}


### PR DESCRIPTION
- **Adds `PauseCommand` and `ResumeCommand`:**  Introduces two new commands, `/pause` and `/resume`, allowing users to control music playback. The purpose is to provide users with greater control over the bot's music playback functionality.
- **Implements `Pause` and `Resume` methods in `GuildPlayer`:**  Adds the logic to pause and resume the audio stream within the `GuildPlayer`. This provides the core functionality for pausing and resuming the playback.
- **Modifies `PlaybackController` to handle pause and resume:** Implements the logic within the `PlaybackController` to actually pause and resume the audio stream, handling timing and the audio decoder.