### PR TITLE
refactor: Implement pause/resume functionality in voice session

### DIFF
--- a/microservices/butakero_bot/internal/domain/ports/discord.go
+++ b/microservices/butakero_bot/internal/domain/ports/discord.go
@@ -3,7 +3,6 @@ package ports
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
-	"github.com/bwmarrin/discordgo"
 	"io"
 )
 
@@ -53,6 +52,7 @@ type (
 		LeaveVoiceChannel() error
 		// SendAudio envía audio a través de la sesión de voz.
 		SendAudio(ctx context.Context, reader io.ReadCloser) error
-		GetVoiceConnection() *discordgo.VoiceConnection
+		Pause()
+		Resume()
 	}
 )


### PR DESCRIPTION
- **Added `Pause()` and `Resume()` methods to the `DiscordVoiceSession`:** This allows pausing and resuming the audio stream directly at the voice session level.
    - Purpose: Provides more granular control over audio playback.
    - Technical Impact: Introduces channels for signaling pause/resume events within the `DiscordVoiceSession`.
- **Modified `PlaybackController` to delegate pause/resume to `VoiceSession`:** The `PlaybackController` now calls the `Pause()` and `Resume()` methods of the `VoiceSession` instead of directly managing the pause state within the playback loop.
    - Purpose: Centralizes the pause/resume logic within the `VoiceSession`.
    - Technical Impact: Simplifies the playback loop in `PlaybackController` and improves separation of concerns.
- **Refactored audio sending logic:** Moved the audio decoding and sending logic entirely to the `VoiceSession` to simplify the Playback Controller.
    - Purpose: Streamlines audio handling and potentially improves performance by centralizing audio operations.