### PR TITLE
fix: Update playback state to idle after song completion

### DIFF
--- a/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
@@ -85,7 +85,7 @@ func (pc *PlaybackController) Resume() error {
 	}
 
 	pc.stateManager.SetState(StatePlaying)
-	pc.voiceSession.Resume() // Delegamos la reanudación al VoiceSession
+	pc.voiceSession.Resume()
 	return nil
 }
 
@@ -191,6 +191,12 @@ func (pc *PlaybackController) playSong(ctx context.Context, song *entity.PlayedS
 			if err != nil && !errors.Is(err, context.Canceled) {
 				pc.logger.Error("Error al reproducir audio", zap.Error(err))
 			}
+
+			pc.mu.Lock()
+			pc.stateManager.SetState(StateIdle)
+			pc.currentSong = nil
+			pc.mu.Unlock()
+
 			return
 		}
 	}


### PR DESCRIPTION
- **Update playback state to StateIdle:** Sets the player state to "Idle" after a song finishes playing. Purpose: Ensures the player reflects the correct state.
- **Clear currentSong after completion:** Sets the `currentSong` to `nil` after playback. Purpose: Clears the reference to the finished song.
- **Added mutex to prevent race condition:** Uses mutex to handle the concurrency between the song end callback and the player controls.