### PR TITLE
refactor: Decouple VoiceStateService into smaller components

### DIFF
--- a/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
@@ -99,7 +99,10 @@ func StartBot() error {
 	}
 
 	songService := service.NewSongService(songRepo, externalService, messageConsumer, logger)
-	voiceStateService := discord.NewVoiceStateService(logger)
+	tracker := discord.NewBotChannelTracker(logger)
+	mover := discord.NewBotMover(logger)
+	playback := discord.NewPlaybackController(logger)
+	voiceStateService := discord.NewVoiceStateService(tracker, mover, playback)
 
 	guildManager := discord.NewGuildManager(discordClient, storageAudio, discordMessenger, logger)
 	eventsHandler := events.NewEventHandler(guildManager, voiceStateService, logger, cfg)

--- a/microservices/butakero_bot/cmd/bot_local/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_local/bot/bot.go
@@ -115,7 +115,10 @@ func StartBot() error {
 	interactionStorage := storage.NewInMemoryInteractionStorage(logger)
 
 	songService := service.NewSongService(songRepo, externalService, messageConsumer, logger)
-	voiceStateService := discord.NewVoiceStateService(logger)
+	tracker := discord.NewBotChannelTracker(logger)
+	mover := discord.NewBotMover(logger)
+	playback := discord.NewPlaybackController(logger)
+	voiceStateService := discord.NewVoiceStateService(tracker, mover, playback)
 	guildManager := discord.NewGuildManager(discordClient, storageAudio, discordMessenger, logger)
 	eventsHandler := events.NewEventHandler(guildManager, voiceStateService, logger, cfg)
 	handler := command.NewCommandHandler(

--- a/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
@@ -19,12 +19,12 @@ type EventHandler struct {
 	guildManager      ports.GuildManager
 	cfg               *config.Config
 	logger            logging.Logger
-	voiceStateService *discord.VoiceStateService
+	voiceStateService discord.VoiceStateHandler
 }
 
 func NewEventHandler(
 	guildManager ports.GuildManager,
-	voiceStateService *discord.VoiceStateService,
+	voiceStateService discord.VoiceStateHandler,
 	logger logging.Logger,
 	cfg *config.Config,
 ) *EventHandler {

--- a/microservices/butakero_bot/internal/infrastructure/discord/voice_state_service.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/voice_state_service.go
@@ -2,19 +2,113 @@ package discord
 
 import (
 	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
 	"github.com/bwmarrin/discordgo"
 	"go.uber.org/zap"
 )
 
-type VoiceStateService struct {
+type VoiceStateHandler interface {
+	HandleVoiceStateChange(guildPlayer ports.GuildPlayer, session *discordgo.Session, vs *discordgo.VoiceStateUpdate) error
+}
+
+type BotChannelTracker struct {
 	logger logging.Logger
 }
 
-func NewVoiceStateService(logger logging.Logger) *VoiceStateService {
+func NewBotChannelTracker(logger logging.Logger) *BotChannelTracker {
+	return &BotChannelTracker{logger: logger}
+}
+
+func (t *BotChannelTracker) GetBotVoiceState(guild *discordgo.Guild, session *discordgo.Session) *discordgo.VoiceState {
+	for _, state := range guild.VoiceStates {
+		if state.UserID == session.State.User.ID {
+			return state
+		}
+	}
+	return nil
+}
+
+func (t *BotChannelTracker) CountUsersInChannel(guild *discordgo.Guild, channelID string, excludeUserID string) int {
+	count := 0
+	for _, state := range guild.VoiceStates {
+		if state.UserID != excludeUserID && state.ChannelID == channelID {
+			count++
+		}
+	}
+	return count
+}
+
+type BotMover struct {
+	logger logging.Logger
+}
+
+func NewBotMover(logger logging.Logger) *BotMover {
+	return &BotMover{logger: logger}
+}
+
+func (m *BotMover) MoveBotToNewChannel(guildPlayer ports.GuildPlayer, newChannelID string, oldChannelID string, userID string) error {
+	stateStorage := guildPlayer.StateStorage()
+	if err := stateStorage.SetVoiceChannel(newChannelID); err != nil {
+		return fmt.Errorf("error al actualizar el canal de voz: %w", err)
+	}
+
+	if err := guildPlayer.JoinVoiceChannel(newChannelID); err != nil {
+		return fmt.Errorf("error al mover el bot al nuevo canal: %w", err)
+	}
+
+	m.logger.Info("Bot movido al nuevo canal",
+		zap.String("oldChannel", oldChannelID),
+		zap.String("newChannel", newChannelID),
+		zap.String("userID", userID))
+
+	return nil
+}
+
+type PlaybackController struct {
+	logger logging.Logger
+}
+
+func NewPlaybackController(logger logging.Logger) *PlaybackController {
+	return &PlaybackController{logger: logger}
+}
+
+func (c *PlaybackController) HandlePlayback(guildPlayer ports.GuildPlayer, currentSong *entity.PlayedSong, vs *discordgo.VoiceStateUpdate, botVoiceState *discordgo.VoiceState, guild *discordgo.Guild, session *discordgo.Session) error {
+	if currentSong != nil && vs.UserID == currentSong.RequestedByID {
+		if vs.ChannelID == "" || (botVoiceState != nil && vs.ChannelID != botVoiceState.ChannelID) {
+			if botVoiceState != nil {
+				usersInBotChannel := 0
+				for _, state := range guild.VoiceStates {
+					if state.UserID != session.State.User.ID && state.ChannelID == botVoiceState.ChannelID {
+						usersInBotChannel++
+					}
+				}
+
+				if usersInBotChannel == 0 {
+					c.logger.Info("No hay usuarios en el canal, deteniendo reproducción",
+						zap.String("channelID", botVoiceState.ChannelID))
+					if err := guildPlayer.Stop(); err != nil {
+						return fmt.Errorf("error al detener la reproducción: %w", err)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type VoiceStateService struct {
+	tracker  *BotChannelTracker
+	mover    *BotMover
+	playback *PlaybackController
+}
+
+func NewVoiceStateService(tracker *BotChannelTracker, mover *BotMover, playback *PlaybackController) *VoiceStateService {
 	return &VoiceStateService{
-		logger: logger,
+		tracker:  tracker,
+		mover:    mover,
+		playback: playback,
 	}
 }
 
@@ -29,46 +123,18 @@ func (s *VoiceStateService) HandleVoiceStateChange(
 		return fmt.Errorf("error al obtener el servidor: %w", err)
 	}
 
-	var botVoiceState *discordgo.VoiceState
-	for _, state := range guild.VoiceStates {
-		if state.UserID == session.State.User.ID {
-			botVoiceState = state
-			break
-		}
-	}
+	botVoiceState := s.tracker.GetBotVoiceState(guild, session)
 
 	if botVoiceState != nil {
 		wasInBotChannel := vs.BeforeUpdate != nil && vs.BeforeUpdate.ChannelID == botVoiceState.ChannelID
-
 		movedToDifferentChannel := vs.ChannelID != "" && vs.ChannelID != botVoiceState.ChannelID
 
 		if wasInBotChannel && movedToDifferentChannel {
 			newChannelID := vs.ChannelID
-
-			usersInCurrentChannel := 0
-			for _, state := range guild.VoiceStates {
-				if state.UserID != session.State.User.ID && state.ChannelID == botVoiceState.ChannelID {
-					usersInCurrentChannel++
-				}
-			}
+			usersInCurrentChannel := s.tracker.CountUsersInChannel(guild, botVoiceState.ChannelID, session.State.User.ID)
 
 			if usersInCurrentChannel == 0 {
-				stateStorage := guildPlayer.StateStorage()
-
-				if err := stateStorage.SetVoiceChannel(newChannelID); err != nil {
-					return fmt.Errorf("error al actualizar el canal de voz: %w", err)
-				}
-
-				if err := guildPlayer.JoinVoiceChannel(newChannelID); err != nil {
-					return fmt.Errorf("error al mover el bot al nuevo canal: %w", err)
-				}
-
-				s.logger.Info("Bot movido al nuevo canal",
-					zap.String("oldChannel", botVoiceState.ChannelID),
-					zap.String("newChannel", newChannelID),
-					zap.String("userID", vs.UserID))
-
-				return nil
+				return s.mover.MoveBotToNewChannel(guildPlayer, newChannelID, botVoiceState.ChannelID, vs.UserID)
 			}
 		}
 	}
@@ -78,26 +144,5 @@ func (s *VoiceStateService) HandleVoiceStateChange(
 		return fmt.Errorf("error al obtener la canción actual: %w", err)
 	}
 
-	if currentSong != nil && vs.UserID == currentSong.RequestedByID {
-		if vs.ChannelID == "" || (botVoiceState != nil && vs.ChannelID != botVoiceState.ChannelID) {
-			if botVoiceState != nil {
-				usersInBotChannel := 0
-				for _, state := range guild.VoiceStates {
-					if state.UserID != session.State.User.ID && state.ChannelID == botVoiceState.ChannelID {
-						usersInBotChannel++
-					}
-				}
-
-				if usersInBotChannel == 0 {
-					s.logger.Info("No hay usuarios en el canal, deteniendo reproducción",
-						zap.String("channelID", botVoiceState.ChannelID))
-					if err := guildPlayer.Stop(); err != nil {
-						return fmt.Errorf("error al detener la reproducción: %w", err)
-					}
-				}
-			}
-		}
-	}
-
-	return nil
+	return s.playback.HandlePlayback(guildPlayer, currentSong, vs, botVoiceState, guild, session)
 }


### PR DESCRIPTION
- **Split VoiceStateService:** The original `VoiceStateService` is now split into `BotChannelTracker`, `BotMover`, and `PlaybackController`. This improves modularity and testability.
- **Introduce Interfaces:** A `VoiceStateHandler` interface is created. `VoiceStateService` now implements it, allowing for easier mocking and dependency injection.
- **Implement new logic:** The `HandlePlayback` method has logic to handle the voice state and stop the player if no one is in the channel