### PR TITLE
refactor: Improve Discord player event handling with specific types

### DIFF
--- a/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
@@ -1,10 +1,19 @@
 package player
 
-// PlayerEvent representa eventos que pueden ocurrir en el reproductor
-type PlayerEvent struct {
-	Type    string
-	Payload interface{}
-}
+type (
+
+	// PlayerEvent representa eventos que pueden ocurrir en el reproductor
+	PlayerEvent struct {
+		Type    string
+		Payload EventPayload
+	}
+
+	// EventPayload contiene datos adicionales para los eventos
+	EventPayload struct {
+		TextChannelID  *string
+		VoiceChannelID *string
+	}
+)
 
 // Event types
 const (
@@ -14,9 +23,3 @@ const (
 	EventStop   = "stop"
 	EventSkip   = "skip"
 )
-
-// EventPayload contiene datos adicionales para los eventos
-type EventPayload struct {
-	TextChannelID  *string
-	VoiceChannelID *string
-}

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
@@ -1,25 +1,39 @@
 package player
 
 type (
-
-	// PlayerEvent representa eventos que pueden ocurrir en el reproductor
-	PlayerEvent struct {
-		Type    string
-		Payload EventPayload
+	// PlayerEvent es la interfaz que todos los eventos del reproductor deben implementar
+	PlayerEvent interface {
+		isPlayerEvent()
+		Type() string
 	}
+)
 
-	// EventPayload contiene datos adicionales para los eventos
-	EventPayload struct {
+type (
+	PlayEvent struct {
 		TextChannelID  *string
 		VoiceChannelID *string
 	}
+
+	PauseEvent struct{}
+
+	ResumeEvent struct{}
+
+	StopEvent struct{}
+
+	SkipEvent struct{}
 )
 
-// Event types
-const (
-	EventPlay   = "play"
-	EventPause  = "pause"
-	EventResume = "resume"
-	EventStop   = "stop"
-	EventSkip   = "skip"
-)
+func (e PlayEvent) Type() string   { return "play" }
+func (e PlayEvent) isPlayerEvent() {}
+
+func (e PauseEvent) Type() string   { return "pause" }
+func (e PauseEvent) isPlayerEvent() {}
+
+func (e ResumeEvent) Type() string   { return "resume" }
+func (e ResumeEvent) isPlayerEvent() {}
+
+func (e StopEvent) Type() string   { return "stop" }
+func (e StopEvent) isPlayerEvent() {}
+
+func (e SkipEvent) Type() string   { return "skip" }
+func (e SkipEvent) isPlayerEvent() {}

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -189,10 +189,7 @@ func (gp *GuildPlayer) handleEvent(ctx context.Context, event PlayerEvent) error
 }
 
 func (gp *GuildPlayer) handlePlayEvent(ctx context.Context, event PlayerEvent) error {
-	payload, ok := event.Payload.(EventPayload)
-	if !ok {
-		return errors.New("payload de evento para reproduccion no valida")
-	}
+	payload := event.Payload
 
 	if payload.TextChannelID != nil {
 		if err := gp.stateStorage.SetTextChannel(*payload.TextChannelID); err != nil {

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -48,12 +48,9 @@ func (gp *GuildPlayer) AddSong(textChannelID, voiceChannelID *string, playedSong
 		return fmt.Errorf("error al agregar la canción: %w", err)
 	}
 
-	gp.eventCh <- PlayerEvent{
-		Type: EventPlay,
-		Payload: EventPayload{
-			TextChannelID:  textChannelID,
-			VoiceChannelID: voiceChannelID,
-		},
+	gp.eventCh <- PlayEvent{
+		TextChannelID:  textChannelID,
+		VoiceChannelID: voiceChannelID,
 	}
 
 	gp.logger.Debug("Canción agregada a la lista", zap.String("título", playedSong.DiscordSong.TitleTrack))
@@ -163,7 +160,7 @@ func (gp *GuildPlayer) Run(ctx context.Context) error {
 		case event := <-gp.eventCh:
 			if err := gp.handleEvent(ctx, event); err != nil {
 				gp.logger.Error("Error al manejar el evento del reproductor",
-					zap.String("evento", event.Type),
+					zap.String("evento", event.Type()),
 					zap.Error(err))
 			}
 		}
@@ -171,33 +168,53 @@ func (gp *GuildPlayer) Run(ctx context.Context) error {
 }
 
 func (gp *GuildPlayer) handleEvent(ctx context.Context, event PlayerEvent) error {
-	switch event.Type {
-	case EventPlay:
-		return gp.handlePlayEvent(ctx, event)
-	case EventPause:
-		return gp.Pause()
-	case EventResume:
-		return gp.Resume()
-	case EventStop:
-		return gp.Stop()
-	case EventSkip:
-		gp.SkipSong()
+	switch e := event.(type) {
+	case PlayEvent:
+		return gp.handlePlayEvent(ctx, e)
+
+	case PauseEvent:
+		if err := gp.Pause(); err != nil {
+			gp.logger.Error("Error al pausar la reproducción", zap.Error(err))
+			return err
+		}
+		gp.logger.Debug("Reproducción pausada")
 		return nil
+
+	case ResumeEvent:
+		if err := gp.Resume(); err != nil {
+			gp.logger.Error("Error al reanudar la reproducción", zap.Error(err))
+			return err
+		}
+		gp.logger.Debug("Reproducción reanudada")
+		return nil
+
+	case StopEvent:
+		if err := gp.Stop(); err != nil {
+			gp.logger.Error("Error al detener la reproducción", zap.Error(err))
+			return err
+		}
+		gp.logger.Debug("Reproducción detenida")
+		return nil
+
+	case SkipEvent:
+		gp.SkipSong()
+		gp.logger.Debug("Canción saltada")
+		return nil
+
 	default:
-		return fmt.Errorf("tipo de evento desconocido: %s", event.Type)
+		gp.logger.Error("Tipo de evento desconocido", zap.String("tipo", event.Type()))
+		return fmt.Errorf("tipo de evento desconocido: %T", event)
 	}
 }
 
-func (gp *GuildPlayer) handlePlayEvent(ctx context.Context, event PlayerEvent) error {
-	payload := event.Payload
-
-	if payload.TextChannelID != nil {
-		if err := gp.stateStorage.SetTextChannel(*payload.TextChannelID); err != nil {
+func (gp *GuildPlayer) handlePlayEvent(ctx context.Context, event PlayEvent) error {
+	if event.TextChannelID != nil {
+		if err := gp.stateStorage.SetTextChannel(*event.TextChannelID); err != nil {
 			return fmt.Errorf("error al setear el canal de texto: %w", err)
 		}
 	}
-	if payload.VoiceChannelID != nil {
-		if err := gp.stateStorage.SetVoiceChannel(*payload.VoiceChannelID); err != nil {
+	if event.VoiceChannelID != nil {
+		if err := gp.stateStorage.SetVoiceChannel(*event.VoiceChannelID); err != nil {
 			return fmt.Errorf("error al setear el canal de voz: %w", err)
 		}
 	}
@@ -218,7 +235,7 @@ func (gp *GuildPlayer) handlePlayEvent(ctx context.Context, event PlayerEvent) e
 
 			select {
 			case event := <-gp.eventCh:
-				if event.Type == EventPlay {
+				if event.Type() == "play" {
 					gp.eventCh <- event
 					return nil
 				}


### PR DESCRIPTION
- **Replaces `PlayerEvent` struct with an interface and concrete event types:** This moves away from a generic event struct with a string `Type` and `Payload` to specific struct types for each event (PlayEvent, PauseEvent, etc.). This improves type safety.
- **Removes `EventPayload` struct:** The payload is now directly embedded within each specific event type.  For example, `PlayEvent` now directly includes `TextChannelID` and `VoiceChannelID`.
- **Updates `handleEvent` to use type assertions:**  The `handleEvent` function now uses type assertions to determine the specific event type and handle it accordingly, eliminating the need for string comparisons.  This improves readability and maintainability.