### PR TITLE
feat: Extend ProcessMedia to include userID and interactionID

### DIFF
--- a/microservices/audio_processor/internal/delivery/queue/processor/media_processor.go
+++ b/microservices/audio_processor/internal/delivery/queue/processor/media_processor.go
@@ -53,7 +53,7 @@ func (p *MediaProcessor) ProcessRequest(ctx context.Context, req *model.MediaReq
 		return err
 	}
 
-	if err := p.coreService.ProcessMedia(reqCtx, mediaDetails); err != nil {
+	if err := p.coreService.ProcessMedia(reqCtx, mediaDetails, req.UserID, req.InteractionID); err != nil {
 		log.Error("Error al procesar media", zap.Error(err))
 		return err
 	}

--- a/microservices/audio_processor/internal/domain/model/message.go
+++ b/microservices/audio_processor/internal/domain/model/message.go
@@ -2,6 +2,8 @@ package model
 
 type (
 	MediaProcessingMessage struct {
+		UserID           string            `json:"user_id"`
+		InteractionID    string            `json:"interaction_id"`
 		VideoID          string            `json:"video_id"`
 		FileData         *FileData         `json:"file_data"`
 		PlatformMetadata *PlatformMetadata `json:"platform_metadata"`

--- a/microservices/audio_processor/internal/domain/ports/services.go
+++ b/microservices/audio_processor/internal/domain/ports/services.go
@@ -31,7 +31,7 @@ type (
 	}
 
 	CoreService interface {
-		ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails) error
+		ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails, userID, interactionID string) error
 	}
 
 	OperationService interface {

--- a/microservices/audio_processor/internal/domain/service/core_service.go
+++ b/microservices/audio_processor/internal/domain/service/core_service.go
@@ -39,7 +39,7 @@ func NewCoreService(
 	}
 }
 
-func (s *coreService) ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails) error {
+func (s *coreService) ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails, userID, interactionID string) error {
 	log := s.logger.With(
 		zap.String("component", "CoreService"),
 		zap.String("method", "ProcessMedia"),
@@ -106,6 +106,8 @@ func (s *coreService) ProcessMedia(ctx context.Context, mediaDetails *model.Medi
 		}
 
 		message := &model.MediaProcessingMessage{
+			InteractionID:    interactionID,
+			UserID:           userID,
 			VideoID:          media.VideoID,
 			FileData:         media.FileData,
 			PlatformMetadata: media.Metadata,

--- a/microservices/audio_processor/internal/domain/service/core_service_test.go
+++ b/microservices/audio_processor/internal/domain/service/core_service_test.go
@@ -47,6 +47,9 @@ func TestCoreService_ProcessMedia_Success(t *testing.T) {
 		Provider:     "youtube",
 	}
 
+	userID := "user_123"
+	interactionID := "interaction_123"
+
 	audioBuffer := bytes.NewBuffer([]byte("test audio data"))
 	fileData := &model.FileData{
 		FilePath: "test-song.dca",
@@ -61,7 +64,7 @@ func TestCoreService_ProcessMedia_Success(t *testing.T) {
 	mockMediaService.On("UpdateMedia", mock.Anything, mediaDetails.ID, mock.AnythingOfType("*model.Media")).Return(nil)
 	mockTopicPublisher.On("PublishMediaProcessed", mock.Anything, mock.AnythingOfType("*model.MediaProcessingMessage")).Return(nil)
 
-	err := service.ProcessMedia(context.Background(), mediaDetails)
+	err := service.ProcessMedia(context.Background(), mediaDetails, userID, interactionID)
 
 	// Assert
 	assert.NoError(t, err)
@@ -103,6 +106,8 @@ func TestCoreService_ProcessMedia_DownloadError(t *testing.T) {
 		ThumbnailURL: "https://example.com/test-thumbnail.jpg",
 		Provider:     "youtube",
 	}
+	userID := "user_123"
+	interactionID := "interaction_123"
 
 	expectedError := errors.New("download failed")
 	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
@@ -111,7 +116,7 @@ func TestCoreService_ProcessMedia_DownloadError(t *testing.T) {
 	mockAudioDownloadService.On("DownloadAndEncode", mock.Anything, mediaDetails.URL).Return((*bytes.Buffer)(nil), expectedError)
 
 	// Act
-	err := service.ProcessMedia(context.Background(), mediaDetails)
+	err := service.ProcessMedia(context.Background(), mediaDetails, userID, interactionID)
 
 	// Assert
 	assert.Error(t, err)
@@ -157,6 +162,9 @@ func TestCoreService_ProcessMedia_StorageError(t *testing.T) {
 		Provider:     "youtube",
 	}
 
+	userID := "user_123"
+	interactionID := "interaction_123"
+
 	audioBuffer := bytes.NewBuffer([]byte("test audio data"))
 	expectedError := errors.New("storage failed")
 
@@ -167,7 +175,7 @@ func TestCoreService_ProcessMedia_StorageError(t *testing.T) {
 	mockAudioStorageService.On("StoreAudio", mock.Anything, audioBuffer, mediaDetails.Title).Return((*model.FileData)(nil), expectedError)
 
 	// Act
-	err := service.ProcessMedia(context.Background(), mediaDetails)
+	err := service.ProcessMedia(context.Background(), mediaDetails, userID, interactionID)
 
 	// Assert
 	assert.Error(t, err)
@@ -211,6 +219,9 @@ func TestCoreService_ProcessMedia_UpdateMediaError(t *testing.T) {
 		Provider:     "youtube",
 	}
 
+	userID := "user_123"
+	interactionID := "interaction_123"
+
 	audioBuffer := bytes.NewBuffer([]byte("test audio data"))
 	fileData := &model.FileData{
 		FilePath: "test-song.dca",
@@ -227,7 +238,7 @@ func TestCoreService_ProcessMedia_UpdateMediaError(t *testing.T) {
 	mockMediaService.On("UpdateMedia", mock.Anything, mediaDetails.ID, mock.AnythingOfType("*model.Media")).Return(expectedError)
 
 	// Act
-	err := service.ProcessMedia(context.Background(), mediaDetails)
+	err := service.ProcessMedia(context.Background(), mediaDetails, userID, interactionID)
 
 	// Assert
 	assert.Error(t, err)
@@ -272,6 +283,9 @@ func TestCoreService_ProcessMedia_PublishError(t *testing.T) {
 		Provider:     "youtube",
 	}
 
+	userID := "user_123"
+	interactionID := "interaction_123"
+
 	audioBuffer := bytes.NewBuffer([]byte("test audio data"))
 	fileData := &model.FileData{
 		FilePath: "test-song.dca",
@@ -289,7 +303,7 @@ func TestCoreService_ProcessMedia_PublishError(t *testing.T) {
 	mockTopicPublisher.On("PublishMediaProcessed", mock.Anything, mock.AnythingOfType("*model.MediaProcessingMessage")).Return(expectedError)
 
 	// Act
-	err := service.ProcessMedia(context.Background(), mediaDetails)
+	err := service.ProcessMedia(context.Background(), mediaDetails, userID, interactionID)
 
 	// Assert
 	assert.Error(t, err)


### PR DESCRIPTION
- **Add `userID` and `interactionID` to `MediaProcessingMessage`:**  This allows the audio processor to associate processed media with a specific user and interaction, providing valuable context for downstream services. No technical impact.
- **Update `ProcessMedia` method signature in `CoreService` and its implementation:**  The `ProcessMedia` method now accepts `userID` and `interactionID` as parameters, allowing the audio processor to receive the needed context. No technical impact.
- **Pass `userID` and `interactionID` through the processing pipeline:** The `userID` and `interactionID` are now passed from the queue consumer to the core service and ultimately included in the `MediaProcessingMessage` published to the message queue. No technical impact.