### PR TITLE
feat: Asynchronous song download requests using message queues

### DIFF
--- a/microservices/butakero_bot/internal/domain/entity/message_queue.go
+++ b/microservices/butakero_bot/internal/domain/entity/message_queue.go
@@ -1,7 +1,11 @@
 package entity
 
+import "time"
+
 type (
 	MessageQueue struct {
+		InteractionID    string   `json:"interaction_id"`
+		UserID           string   `json:"user_id"`
 		VideoID          string   `json:"video_id"`
 		Message          string   `json:"message"`
 		PlatformMetadata Metadata `json:"platform_metadata"`
@@ -22,5 +26,13 @@ type (
 		FilePath string `json:"file_path" bson:"file_path" dynamodbav:"file_path"`
 		FileSize string `json:"file_size" bson:"file_size" dynamodbav:"file_size"`
 		FileType string `json:"file_type" bson:"file_type" dynamodbav:"file_type"`
+	}
+
+	SongRequestMessage struct {
+		InteractionID string    `json:"interaction_id"`
+		UserID        string    `json:"user_id"`
+		Song          string    `json:"song"`
+		ProviderType  string    `json:"provider_type"`
+		Timestamp     time.Time `json:"timestamp"`
 	}
 )

--- a/microservices/butakero_bot/internal/domain/ports/message_queue.go
+++ b/microservices/butakero_bot/internal/domain/ports/message_queue.go
@@ -9,7 +9,13 @@ import (
 // Cuando se inicia la descarga de la canción desde el SongDownloader,
 // el microservicio de descarga envía el resultado a una cola. Los estados posibles
 // son "success" y "error".
-type MessageConsumer interface {
-	ConsumeMessages(ctx context.Context, offset int64) error
-	GetMessagesChannel() <-chan *entity.MessageQueue
-}
+type (
+	MessageConsumer interface {
+		ConsumeMessages(ctx context.Context, offset int64) error
+		GetMessagesChannel() <-chan *entity.MessageQueue
+	}
+
+	MessageProducer interface {
+		PublishSongRequest(ctx context.Context, message *entity.SongRequestMessage) error
+	}
+)

--- a/microservices/butakero_bot/internal/domain/ports/service.go
+++ b/microservices/butakero_bot/internal/domain/ports/service.go
@@ -14,6 +14,6 @@ type (
 	}
 
 	SongService interface {
-		GetOrDownloadSong(ctx context.Context, songInput, providerType string) (*entity.DiscordEntity, error)
+		GetOrDownloadSong(ctx context.Context, interactionID, userID, songInput, providerType string) (*entity.DiscordEntity, error)
 	}
 )

--- a/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
@@ -48,6 +48,9 @@ func NewCommandHandler(
 }
 
 func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.InteractionCreate, opt *discordgo.ApplicationCommandInteractionDataOption) {
+	userID := ic.Member.User.ID
+	interactionID := ic.ID
+
 	vs, ok := h.isUserInVoiceChannel(s, ic)
 	if !ok {
 		return
@@ -72,7 +75,7 @@ func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.Interactio
 	}
 
 	go func() {
-		song, err := h.songService.GetOrDownloadSong(context.Background(), input, "youtube")
+		song, err := h.songService.GetOrDownloadSong(context.Background(), interactionID, userID, input, "youtube")
 		if err != nil {
 			h.logger.Error("Error al obtener canción", zap.Error(err))
 			if err := h.messenger.EditOriginalResponse(domainInteraction, &entity.WebhookEdit{

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_consumer_integration_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_consumer_integration_test.go
@@ -44,6 +44,8 @@ func TestIntegrationKafkaConsumer(t *testing.T) {
 	}()
 
 	successJSON := `{
+		"user_id": "user_123",
+		"interaction_id": "interaction_123",
         "video_id": "19f6c66f-26f3-4ccf-bfc7-967449a95ad4",
         "status": "success",
         "message": "Procesamiento exitoso",

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_consumer_unit_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_consumer_unit_test.go
@@ -38,7 +38,7 @@ func TestKafkaConsumer_Close(t *testing.T) {
 	config := sarama.NewConfig()
 	mockConsumer := mocks.NewConsumer(t, config)
 	mockLogger := new(logging.MockLogger)
-	consumer := &KafkaConsumer{
+	consumer := &ConsumerKafka{
 		consumer:    mockConsumer,
 		brokers:     []string{"dummy"},
 		topic:       "test-topic",
@@ -76,7 +76,7 @@ func TestHandleSuccessMessage(t *testing.T) {
         "success": true
     }`
 	mockLogger := new(logging.MockLogger)
-	consumer := &KafkaConsumer{
+	consumer := &ConsumerKafka{
 		messageChan: make(chan *entity.MessageQueue, 1),
 		logger:      mockLogger,
 	}
@@ -120,7 +120,7 @@ func TestHandleErrorMessage(t *testing.T) {
         "success": false
     }`
 	mockLogger := new(logging.MockLogger)
-	consumer := &KafkaConsumer{
+	consumer := &ConsumerKafka{
 		messageChan: make(chan *entity.MessageQueue, 1),
 		logger:      mockLogger,
 	}

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer.go
@@ -1,0 +1,118 @@
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/IBM/sarama"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"go.uber.org/zap"
+	"time"
+)
+
+type ProducerKafka struct {
+	producer sarama.SyncProducer
+	cfg      *config.Config
+	logger   logging.Logger
+}
+
+func NewSaramaProducer(cfg *config.Config, logger logging.Logger) (ports.MessageProducer, error) {
+	saramaConfig := sarama.NewConfig()
+	saramaConfig.Producer.Return.Errors = true
+
+	logger = logger.With(
+		zap.String("component", "kafka_consumer"),
+		zap.Strings("brokers", cfg.QueueConfig.KafkaConfig.Brokers),
+		zap.String("topic", cfg.QueueConfig.KafkaConfig.Topics.BotDownloadRequest),
+	)
+
+	logger.Info("Iniciando configuración del producer Kafka")
+
+	if cfg.QueueConfig.KafkaConfig.TLS.Enabled {
+		logger.Info("Configurando conexión TLS")
+		tlsConfig, err := shared.ConfigureTLS(shared.TLSConfig{
+			Enabled:  cfg.QueueConfig.KafkaConfig.TLS.Enabled,
+			CAFile:   cfg.QueueConfig.KafkaConfig.TLS.CAFile,
+			CertFile: cfg.QueueConfig.KafkaConfig.TLS.CertFile,
+			KeyFile:  cfg.QueueConfig.KafkaConfig.TLS.KeyFile,
+		})
+		if err != nil {
+			logger.Error("Error al crear configuración TLS", zap.Error(err))
+			return nil, fmt.Errorf("error creando configuración TLS: %w", err)
+		}
+		saramaConfig.Net.TLS.Enable = true
+		saramaConfig.Net.TLS.Config = tlsConfig
+		logger.Debug("Configuración TLS aplicada")
+	} else {
+		logger.Info("TLS no está habilitado")
+	}
+
+	producer, err := sarama.NewSyncProducer(cfg.QueueConfig.KafkaConfig.Brokers, saramaConfig)
+	if err != nil {
+		logger.Error("Error al crear el productor de Sarama", zap.Error(err))
+		return nil, fmt.Errorf("error al crear el productor de Sarama: %w", err)
+	}
+
+	return &ProducerKafka{
+		producer: producer,
+		logger:   logger,
+		cfg:      cfg,
+	}, nil
+}
+
+func (p *ProducerKafka) PublishSongRequest(ctx context.Context, message *entity.SongRequestMessage) error {
+	log := p.logger.With(
+		zap.String("component", "ProducerKafka"),
+		zap.String("method", "PublishSongRequest"),
+		zap.String("topic", p.cfg.QueueConfig.KafkaConfig.Topics.BotDownloadRequest),
+		zap.String("interaction_id", message.InteractionID),
+	)
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("contexto cancelado antes de publicar: %w", ctx.Err())
+	default:
+	}
+
+	jsonData, err := json.Marshal(message)
+	if err != nil {
+		log.Error("Error al serializar el mensaje", zap.Error(err))
+		return fmt.Errorf("error al serializar el mensaje: %w", err)
+	}
+
+	msg := &sarama.ProducerMessage{
+		Topic:     p.cfg.QueueConfig.KafkaConfig.Topics.BotDownloadRequest,
+		Key:       sarama.StringEncoder(message.InteractionID),
+		Value:     sarama.ByteEncoder(jsonData),
+		Timestamp: time.Now(),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		partition, offset, err := p.producer.SendMessage(msg)
+		if err != nil {
+			done <- err
+			return
+		}
+		log.Info("Mensaje publicado exitosamente",
+			zap.Int32("partition", partition),
+			zap.Int64("offset", offset),
+			zap.String("interaction_id", message.InteractionID))
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("operación cancelada mientras se publicaba: %w", ctx.Err())
+	}
+}
+
+func (p *ProducerKafka) Close() error {
+	return p.producer.Close()
+}

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer_integration_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer_integration_test.go
@@ -1,0 +1,1 @@
+package kafka

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer.go
@@ -30,7 +30,7 @@ type SQSConsumer struct {
 func NewSQSConsumer(client ClientSQS, config *config.Config, logger logging.Logger) *SQSConsumer {
 	logger = logger.With(
 		zap.String("component", "sqs_consumer"),
-		zap.String("queueURL", config.QueueConfig.SQSConfig.QueueURL),
+		zap.String("queueURL", config.QueueConfig.SQSConfig.Queues.BotDownloadStatusQueueURL),
 		zap.Int32("maxMessages", config.QueueConfig.SQSConfig.MaxMessages),
 		zap.Int32("waitTimeSeconds", config.QueueConfig.SQSConfig.WaitTimeSeconds),
 	)
@@ -69,7 +69,7 @@ func (s *SQSConsumer) receiveAndProcessMessages(ctx context.Context) {
 	logger := s.logger.With(zap.String("method", "receiveAndProcessMessages"))
 
 	input := &sqs.ReceiveMessageInput{
-		QueueUrl:            aws.String(s.cfg.QueueConfig.SQSConfig.QueueURL),
+		QueueUrl:            aws.String(s.cfg.QueueConfig.SQSConfig.Queues.BotDownloadStatusQueueURL),
 		MaxNumberOfMessages: s.cfg.QueueConfig.SQSConfig.MaxMessages,
 		WaitTimeSeconds:     s.cfg.QueueConfig.SQSConfig.WaitTimeSeconds,
 		MessageSystemAttributeNames: []types.MessageSystemAttributeName{
@@ -131,7 +131,7 @@ func (s *SQSConsumer) deleteMessage(ctx context.Context, msg types.Message) {
 	)
 
 	deleteInput := &sqs.DeleteMessageInput{
-		QueueUrl:      aws.String(s.cfg.QueueConfig.SQSConfig.QueueURL),
+		QueueUrl:      aws.String(s.cfg.QueueConfig.SQSConfig.Queues.BotDownloadStatusQueueURL),
 		ReceiptHandle: msg.ReceiptHandle,
 	}
 

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer_integration_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer_integration_test.go
@@ -1,4 +1,4 @@
-////go:build integration
+//go:build integration
 
 package sqs
 
@@ -91,7 +91,9 @@ func TestSQSConsumerIntegration(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        container.QueueURL,
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: container.QueueURL,
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 5,
 			},
@@ -140,7 +142,9 @@ func TestSQSConsumerIntegration_ErrorStatus(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        container.QueueURL,
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: container.QueueURL,
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 5,
 			},

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer_test.go
@@ -39,7 +39,9 @@ func TestNewSQSConsumer(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},
@@ -54,7 +56,7 @@ func TestNewSQSConsumer(t *testing.T) {
 	// Assert
 	assert.NotNil(t, consumer)
 	assert.Equal(t, mockClient, consumer.client)
-	assert.Equal(t, cfg.QueueConfig.SQSConfig.QueueURL, consumer.cfg.QueueConfig.SQSConfig.QueueURL)
+	assert.Equal(t, cfg.QueueConfig.SQSConfig.Queues.BotDownloadStatusQueueURL, consumer.cfg.QueueConfig.SQSConfig.Queues.BotDownloadStatusQueueURL)
 	assert.Equal(t, cfg.QueueConfig.SQSConfig.MaxMessages, consumer.cfg.QueueConfig.SQSConfig.MaxMessages)
 	assert.Equal(t, cfg.QueueConfig.SQSConfig.WaitTimeSeconds, consumer.cfg.QueueConfig.SQSConfig.WaitTimeSeconds)
 	assert.NotNil(t, consumer.messageChan)
@@ -69,7 +71,9 @@ func TestSQSConsumer_ConsumeMessages(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},
@@ -117,7 +121,9 @@ func TestSQSConsumer_receiveAndProcessMessages_Success(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},
@@ -167,7 +173,9 @@ func TestSQSConsumer_receiveAndProcessMessages_Error(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},
@@ -203,7 +211,9 @@ func TestSQSConsumer_handleMessage_Success(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},
@@ -255,7 +265,9 @@ func TestSQSConsumer_handleMessage_WarningStatus(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},
@@ -295,7 +307,9 @@ func TestSQSConsumer_handleMessage_UnmarshalError(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},
@@ -324,7 +338,9 @@ func TestSQSConsumer_GetMessagesChannel(t *testing.T) {
 	cfg := &config.Config{
 		QueueConfig: config.QueueConfig{
 			SQSConfig: config.SQSConfig{
-				QueueURL:        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				Queues: &config.QueuesSQS{
+					BotDownloadStatusQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+				},
 				MaxMessages:     10,
 				WaitTimeSeconds: 20,
 			},

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer.go
@@ -1,0 +1,103 @@
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsCfg "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"go.uber.org/zap"
+)
+
+type ProducerSQS struct {
+	client *sqs.Client
+	cfg    *config.Config
+	logger logging.Logger
+}
+
+func NewProducerSQS(cfgApplication *config.Config, log logging.Logger) (ports.MessageProducer, error) {
+	log.Info("Inicializando productor SQS",
+		zap.String("queue_url", cfgApplication.QueueConfig.SQSConfig.Queues.BotDownloadRequestsQueueURL))
+
+	log.Debug("Cargando configuración AWS", zap.String("region", cfgApplication.AWS.Region))
+	cfg, err := awsCfg.LoadDefaultConfig(context.TODO(),
+		awsCfg.WithRegion(cfgApplication.AWS.Region))
+	if err != nil {
+		log.Error("Error cargando configuración AWS", zap.Error(err))
+		return nil, fmt.Errorf("error cargando configuración AWS: %w", err)
+	}
+
+	log.Debug("Creando cliente SQS")
+	sqsClient := sqs.NewFromConfig(cfg)
+
+	log.Info("Productor SQS inicializado correctamente",
+		zap.String("queue_url", cfgApplication.QueueConfig.SQSConfig.Queues.BotDownloadRequestsQueueURL))
+	return &ProducerSQS{
+		client: sqsClient,
+		cfg:    cfgApplication,
+		logger: log,
+	}, nil
+}
+
+func (p *ProducerSQS) PublishSongRequest(ctx context.Context, message *entity.SongRequestMessage) error {
+	log := p.logger.With(
+		zap.String("component", "SQSProducer"),
+		zap.String("method", "PublishSongRequest"),
+		zap.String("queue_url", p.cfg.QueueConfig.SQSConfig.Queues.BotDownloadRequestsQueueURL),
+		zap.String("interaction_id", message.InteractionID),
+	)
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("contexto cancelado antes de publicar: %w", ctx.Err())
+	default:
+	}
+
+	jsonData, err := json.Marshal(message)
+	if err != nil {
+		log.Error("Error al serializar el mensaje", zap.Error(err))
+		return fmt.Errorf("error al serializar el mensaje: %w", err)
+	}
+
+	msg := &sqs.SendMessageInput{
+		QueueUrl:    aws.String(p.cfg.QueueConfig.SQSConfig.Queues.BotDownloadRequestsQueueURL),
+		MessageBody: aws.String(string(jsonData)),
+		MessageAttributes: map[string]types.MessageAttributeValue{
+			"InteractionID": {
+				DataType:    aws.String("String"),
+				StringValue: aws.String(message.InteractionID),
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		resp, err := p.client.SendMessage(ctx, msg)
+		if err != nil {
+			done <- err
+			return
+		}
+		log.Info("Mensaje publicado exitosamente",
+			zap.String("message_id", *resp.MessageId),
+			zap.String("interaction_id", message.InteractionID))
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("operación cancelada mientras se publicaba: %w", ctx.Err())
+	}
+}
+
+func (p *ProducerSQS) Close() error {
+	return nil
+}

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer_integration_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer_integration_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	cfgAws "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/testcontainers/testcontainers-go/modules/localstack"
+	"testing"
+	"time"
+
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+type TestContainerProducer struct {
+	Container *localstack.LocalStackContainer
+	Client    *sqs.Client
+	QueueURL  string
+}
+
+func setupTestContainerProducer(ctx context.Context) (*TestContainerProducer, error) {
+	container, err := localstack.Run(ctx, "localstack/localstack:4.1.1", testcontainers.WithEnv(map[string]string{
+		"SERVICES":           "sqs",
+		"AWS_DEFAULT_REGION": "us-east-1",
+		"EDGE_PORT":          "4566",
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("error iniciando contenedor: %w", err)
+	}
+
+	port, err := container.MappedPort(ctx, "4566")
+	if err != nil {
+		return nil, fmt.Errorf("error obteniendo puerto mapeado: %w", err)
+	}
+
+	customEndpoint := fmt.Sprintf("http://localhost:%s", port)
+	cfg, err := cfgAws.LoadDefaultConfig(ctx,
+		cfgAws.WithRegion("us-east-1"),
+		cfgAws.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "test",
+		)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error cargando config AWS: %w", err)
+	}
+
+	client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+		o.BaseEndpoint = aws.String(customEndpoint)
+	})
+
+	queueName := "test-song-requests-queue"
+	createQueueInput := &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	}
+
+	result, err := client.CreateQueue(ctx, createQueueInput)
+	if err != nil {
+		return nil, fmt.Errorf("error creando cola: %w", err)
+	}
+
+	return &TestContainerProducer{
+		Container: container,
+		Client:    client,
+		QueueURL:  *result.QueueUrl,
+	}, nil
+
+}
+
+func TestProducerSQS_PublishSongRequest(t *testing.T) {
+	ctx := context.Background()
+
+	container, err := setupTestContainerProducer(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := container.Container.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	}()
+
+	cfg := &config.Config{
+		AWS: config.AWSConfig{
+			Region: "us-east-1",
+		},
+		QueueConfig: config.QueueConfig{
+			SQSConfig: config.SQSConfig{
+				Queues: &config.QueuesSQS{
+					BotDownloadRequestsQueueURL: container.QueueURL,
+				},
+				MaxMessages:     10,
+				WaitTimeSeconds: 5,
+			},
+		},
+	}
+
+	logger, err := logging.NewDevelopmentLogger()
+	require.NoError(t, err)
+
+	producer := &ProducerSQS{
+		container.Client,
+		cfg,
+		logger,
+	}
+	require.NoError(t, err)
+
+	testMessage := &entity.SongRequestMessage{
+		InteractionID: "test-interaction-123",
+		UserID:        "user-456",
+		Song:          "Never Gonna Give You Up",
+		ProviderType:  "youtube",
+		Timestamp:     time.Now(),
+	}
+
+	err = producer.PublishSongRequest(ctx, testMessage)
+	require.NoError(t, err)
+
+	receiveResult, err := container.Client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:              aws.String(container.QueueURL),
+		MaxNumberOfMessages:   1,
+		WaitTimeSeconds:       5,
+		MessageAttributeNames: []string{"All"},
+	})
+	require.NoError(t, err)
+	require.Len(t, receiveResult.Messages, 1, "Expected to receive 1 message from queue")
+
+	message := receiveResult.Messages[0]
+	assert.NotNil(t, message.MessageId, "Message ID should not be nil")
+
+	interactionID, ok := message.MessageAttributes["InteractionID"]
+	require.True(t, ok, "InteractionID attribute should exist")
+	assert.Equal(t, testMessage.InteractionID, *interactionID.StringValue)
+
+	var receivedMessage entity.SongRequestMessage
+	err = json.Unmarshal([]byte(*message.Body), &receivedMessage)
+	require.NoError(t, err)
+
+	assert.Equal(t, testMessage.InteractionID, receivedMessage.InteractionID)
+	assert.Equal(t, testMessage.UserID, receivedMessage.UserID)
+	assert.Equal(t, testMessage.Song, receivedMessage.Song)
+	assert.Equal(t, testMessage.ProviderType, receivedMessage.ProviderType)
+
+	_, err = container.Client.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+		QueueUrl:      aws.String(container.QueueURL),
+		ReceiptHandle: message.ReceiptHandle,
+	})
+	require.NoError(t, err)
+}
+
+func TestProducerSQS_PublishSongRequest_ContextCancelled(t *testing.T) {
+	ctx := context.Background()
+
+	container, err := setupTestContainerProducer(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := container.Container.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	}()
+
+	cfg := &config.Config{
+		AWS: config.AWSConfig{
+			Region: "us-east-1",
+		},
+		QueueConfig: config.QueueConfig{
+			SQSConfig: config.SQSConfig{
+				Queues: &config.QueuesSQS{
+					BotDownloadRequestsQueueURL: container.QueueURL,
+				},
+			},
+		},
+	}
+
+	logger, err := logging.NewDevelopmentLogger()
+	require.NoError(t, err)
+
+	producer := &ProducerSQS{
+		container.Client,
+		cfg,
+		logger,
+	}
+
+	testMessage := &entity.SongRequestMessage{
+		InteractionID: "test-interaction-123",
+		UserID:        "user-456",
+		Song:          "Never Gonna Give You Up",
+		ProviderType:  "youtube",
+		Timestamp:     time.Now(),
+	}
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err = producer.PublishSongRequest(cancelledCtx, testMessage)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "contexto cancelado")
+}

--- a/microservices/butakero_bot/internal/shared/config/config.go
+++ b/microservices/butakero_bot/internal/shared/config/config.go
@@ -35,9 +35,14 @@ type (
 	}
 
 	SQSConfig struct {
-		QueueURL        string
+		Queues          *QueuesSQS
 		MaxMessages     int32
 		WaitTimeSeconds int32
+	}
+
+	QueuesSQS struct {
+		BotDownloadStatusQueueURL   string
+		BotDownloadRequestsQueueURL string
 	}
 
 	Discord struct {
@@ -46,8 +51,13 @@ type (
 
 	KafkaConfig struct {
 		Brokers []string
-		Topic   string
+		Topics  *KafkaTopics
 		TLS     shared.TLSConfig
+	}
+
+	KafkaTopics struct {
+		BotDownloadStatus  string
+		BotDownloadRequest string
 	}
 
 	StorageConfig struct {
@@ -127,7 +137,10 @@ func LoadConfig() (*Config, error) {
 		QueueConfig: QueueConfig{
 			KafkaConfig: KafkaConfig{
 				Brokers: viper.GetStringSlice("KAFKA_BROKERS"),
-				Topic:   viper.GetString("KAFKA_TOPIC"),
+				Topics: &KafkaTopics{
+					BotDownloadRequest: viper.GetString("KAFKA_BOT_DOWNLOAD_REQUESTS"),
+					BotDownloadStatus:  viper.GetString("KAFKA_BOT_DOWNLOAD_STATUS"),
+				},
 				TLS: shared.TLSConfig{
 					Enabled:  viper.GetBool("KAFKA_TLS_ENABLED"),
 					CAFile:   viper.GetString("KAFKA_TLS_CA_FILE"),
@@ -213,7 +226,10 @@ func LoadConfigAws() (*Config, error) {
 		},
 		QueueConfig: QueueConfig{
 			SQSConfig: SQSConfig{
-				QueueURL: secrets["SQS_QUEUE_URL"],
+				Queues: &QueuesSQS{
+					BotDownloadRequestsQueueURL: secrets["QUEUE_BOT_DOWNLOAD_REQUESTS"],
+					BotDownloadStatusQueueURL:   secrets["QUEUE_BOT_DOWNLOAD_STATUS"],
+				},
 			},
 		},
 	}


### PR DESCRIPTION
- **Replaces direct download requests with asynchronous message queue:**  The `songService.GetOrDownloadSong` function now sends a message to a queue (Kafka or SQS) instead of directly calling the audio download service. This improves the bot's responsiveness and scalability.
    - Purpose: Decouples the bot from the download service, allowing for independent scaling and error handling. Improves user experience by providing immediate feedback and avoiding blocking the bot.
    - Technical impact: Introduces message queueing concepts and requires proper configuration of the chosen message queue (Kafka or SQS). Changes the data flow for song downloads.

- **Implements Message Producers (Kafka and SQS):** Introduces interfaces and implementations to produce song requests to either Kafka or SQS based on the configuration.
    - Purpose:  Abstracts the message queue interaction to allow for different queuing technologies without impacting the core logic.
    - Technical impact: Introduces the need to configure and manage either Kafka or SQS producers depending on the deployment environment (local vs AWS).

- **Removes direct dependency on external audio service:** The `songService` no longer depends on the `ExternalSongService` and directly publishes messages to a message queue.
    - Purpose:  Decouples song requests from the immediate availability/responsiveness of the external audio service. The responsibility to request the download is moved to the consumers of the queue.
    - Technical impact: Removes the need for the bot to have a direct connection to the external audio service.