### PR TITLE
feat: Implement separate SQS queues for requests/status + fix duplicate Guild...

### DIFF
--- a/microservices/audio_processor/internal/config/config.go
+++ b/microservices/audio_processor/internal/config/config.go
@@ -92,7 +92,7 @@ func LoadConfigAws() *Config {
 	}
 	return &Config{
 		Environment: "prod",
-		NumWorkers:  2,
+		NumWorkers:  getSecretAsInt(secrets, "NUM_WORKERS", 2),
 		Service: ServiceConfig{
 			MaxAttempts: getSecretAsInt(secrets, "SERVICE_MAX_ATTEMPTS", 5),
 			Timeout:     time.Duration(getSecretAsInt(secrets, "SERVICE_TIMEOUT", 1)) * time.Minute,
@@ -107,7 +107,10 @@ func LoadConfigAws() *Config {
 		Messaging: MessagingConfig{
 			Type: "sqs",
 			SQS: &SQSConfig{
-				QueueURL: secrets["SQS_QUEUE_URL"],
+				QueueURLs: &SQSQueues{
+					BotDownloadStatusURL:   secrets["SQS_BOT_DOWNLOAD_STATUS_URL"],
+					BotDownloadRequestsURL: secrets["SQS_BOT_DOWNLOAD_REQUESTS_URL"],
+				},
 			},
 		},
 		API: APIConfig{

--- a/microservices/audio_processor/internal/config/types.go
+++ b/microservices/audio_processor/internal/config/types.go
@@ -58,7 +58,12 @@ type (
 
 	// SQSConfig configuración específica de SQS
 	SQSConfig struct {
-		QueueURL string
+		QueueURLs *SQSQueues
+	}
+
+	SQSQueues struct {
+		BotDownloadStatusURL   string
+		BotDownloadRequestsURL string
 	}
 
 	// StorageConfig maneja la configuración de almacenamiento

--- a/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_consumer.go
+++ b/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_consumer.go
@@ -25,7 +25,7 @@ type ConsumerSQS struct {
 
 func NewConsumerSQS(cfgApplication *config.Config, log logger.Logger) (ports.MessageConsumer, error) {
 	log.Info("Inicializando consumidor SQS",
-		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURL))
+		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURLs.BotDownloadRequestsURL))
 
 	log.Debug("Cargando configuración AWS", zap.String("region", cfgApplication.AWS.Region))
 	cfg, err := awsCfg.LoadDefaultConfig(context.TODO(),
@@ -39,7 +39,7 @@ func NewConsumerSQS(cfgApplication *config.Config, log logger.Logger) (ports.Mes
 	sqsClient := sqs.NewFromConfig(cfg)
 
 	log.Info("Consumidor SQS inicializado correctamente",
-		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURL))
+		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURLs.BotDownloadRequestsURL))
 	return &ConsumerSQS{
 		client: sqsClient,
 		cfg:    cfgApplication,
@@ -51,7 +51,7 @@ func (c *ConsumerSQS) GetRequestsChannel(ctx context.Context) (<-chan *model.Med
 	log := c.logger.With(
 		zap.String("component", "sqs_consumer"),
 		zap.String("method", "GetRequestsChannel"),
-		zap.String("queue_url", c.cfg.Messaging.SQS.QueueURL),
+		zap.String("queue_url", c.cfg.Messaging.SQS.QueueURLs.BotDownloadRequestsURL),
 	)
 
 	log.Info("Iniciando canal de solicitudes SQS")
@@ -68,7 +68,7 @@ func (c *ConsumerSQS) consumeLoop(ctx context.Context, out chan<- *model.MediaRe
 	log := c.logger.With(
 		zap.String("component", "sqs_consumer"),
 		zap.String("method", "consumeLoop"),
-		zap.String("queue_url", c.cfg.Messaging.SQS.QueueURL),
+		zap.String("queue_url", c.cfg.Messaging.SQS.QueueURLs.BotDownloadRequestsURL),
 	)
 
 	log.Info("Loop de consumo SQS iniciado")
@@ -98,11 +98,11 @@ func (c *ConsumerSQS) receiveMessages(ctx context.Context, out chan<- *model.Med
 	log := c.logger.With(
 		zap.String("component", "sqs_consumer"),
 		zap.String("method", "receiveMessages"),
-		zap.String("queue_url", c.cfg.Messaging.SQS.QueueURL),
+		zap.String("queue_url", c.cfg.Messaging.SQS.QueueURLs.BotDownloadRequestsURL),
 	)
 
 	input := &sqs.ReceiveMessageInput{
-		QueueUrl:            aws.String(c.cfg.Messaging.SQS.QueueURL),
+		QueueUrl:            aws.String(c.cfg.Messaging.SQS.QueueURLs.BotDownloadRequestsURL),
 		MaxNumberOfMessages: 10,
 		WaitTimeSeconds:     20,
 		MessageSystemAttributeNames: []types.MessageSystemAttributeName{
@@ -172,7 +172,7 @@ func (c *ConsumerSQS) deleteMessage(ctx context.Context, receiptHandle *string) 
 
 	log.Debug("Enviando solicitud de eliminación de mensaje")
 	_, err := c.client.DeleteMessage(ctx, &sqs.DeleteMessageInput{
-		QueueUrl:      aws.String(c.cfg.Messaging.SQS.QueueURL),
+		QueueUrl:      aws.String(c.cfg.Messaging.SQS.QueueURLs.BotDownloadRequestsURL),
 		ReceiptHandle: receiptHandle,
 	})
 

--- a/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_producer.go
+++ b/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_producer.go
@@ -23,7 +23,7 @@ type ProducerSQS struct {
 
 func NewProducerSQS(cfgApplication *config.Config, log logger.Logger) (ports.MessageProducer, error) {
 	log.Info("Inicializando productor SQS",
-		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURL))
+		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURLs.BotDownloadStatusURL))
 
 	log.Debug("Cargando configuración AWS", zap.String("region", cfgApplication.AWS.Region))
 	cfg, err := awsCfg.LoadDefaultConfig(context.TODO(),
@@ -37,7 +37,7 @@ func NewProducerSQS(cfgApplication *config.Config, log logger.Logger) (ports.Mes
 	sqsClient := sqs.NewFromConfig(cfg)
 
 	log.Info("Productor SQS inicializado correctamente",
-		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURL))
+		zap.String("queue_url", cfgApplication.Messaging.SQS.QueueURLs.BotDownloadStatusURL))
 	return &ProducerSQS{
 		client: sqsClient,
 		cfg:    cfgApplication,
@@ -64,15 +64,15 @@ func (p *ProducerSQS) Publish(ctx context.Context, msg *model.MediaProcessingMes
 
 	input := &sqs.SendMessageInput{
 		MessageBody: aws.String(string(body)),
-		QueueUrl:    aws.String(p.cfg.Messaging.SQS.QueueURL),
+		QueueUrl:    aws.String(p.cfg.Messaging.SQS.QueueURLs.BotDownloadStatusURL),
 	}
 
 	log.Debug("Enviando mensaje a SQS",
-		zap.String("queue_url", p.cfg.Messaging.SQS.QueueURL))
+		zap.String("queue_url", p.cfg.Messaging.SQS.QueueURLs.BotDownloadStatusURL))
 	result, err := p.client.SendMessage(ctx, input)
 	if err != nil {
 		log.Error("Error publicando mensaje en SQS",
-			zap.String("queue_url", p.cfg.Messaging.SQS.QueueURL),
+			zap.String("queue_url", p.cfg.Messaging.SQS.QueueURLs.BotDownloadStatusURL),
 			zap.Error(err))
 		return err
 	}

--- a/microservices/audio_processor/song-downloader-infra/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/main.tf
@@ -25,12 +25,14 @@ module "secret_manager" {
   secret_values = {
     "GIN_MODE": var.gin_mode
     "YOUTUBE_API_KEY": var.youtube_api_key
-    "SQS_QUEUE_URL": module.messaging.queue_url
     "S3_BUCKET_NAME": module.storage.bucket_name
     "DYNAMODB_TABLE_SONGS": module.database.songs_table_name
     "SERVICE_MAX_ATTEMPTS": var.service_max_attempts
     "SERVICE_TIMEOUT": var.service_timeout
     "AUDIO_PROCESSOR_URL": "http://${module.alb.alb_dns_name}"
+    SQS_BOT_DOWNLOAD_STATUS_URL: module.messaging.status_queue_url
+    SQS_BOT_DOWNLOAD_REQUESTS_URL: module.messaging.requests_queue_url
+    NUM_WORKERS: var.workers_count
   }
   tags = var.sm_tags
   secret_name = var.secret_name
@@ -79,7 +81,7 @@ module "iam" {
   environment  = var.environment
 
   s3_bucket_arns      = [module.storage.bucket_arn]
-  sqs_queue_arns      = [module.messaging.queue_arn]
+  sqs_queue_arns      = module.messaging.queues_arn
   secrets_manager_arns = [ module.secret_manager.secret_arn]
   dynamodb_table_arns = module.database.table_arns
   tags                = var.iam_tags

--- a/microservices/audio_processor/song-downloader-infra/modules/messaging/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/messaging/main.tf
@@ -1,5 +1,16 @@
-resource "aws_sqs_queue" "main" {
-  name = "${var.project_name}-queue-${var.environment}"
+resource "aws_sqs_queue" "download_status" {
+  name = "${var.project_name}-download-status-${var.environment}"
+
+  delay_seconds = 0
+  max_message_size = 262144
+  message_retention_seconds = 345600
+  visibility_timeout_seconds = 60
+
+  tags = var.tags_sqs_queue
+}
+
+resource "aws_sqs_queue" "download_requests" {
+  name = "${var.project_name}-download-requests-${var.environment}"
 
   delay_seconds = 0
   max_message_size = 262144

--- a/microservices/audio_processor/song-downloader-infra/modules/messaging/outputs.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/messaging/outputs.tf
@@ -1,9 +1,17 @@
-output "queue_url" {
-  description = "URL de la cola SQS"
-  value       = aws_sqs_queue.main.url
+output "status_queue_url" {
+  description = "URL de la cola SQS para estados de descarga"
+  value       = aws_sqs_queue.download_status.url
 }
 
-output "queue_arn" {
-  description = "ARN de la cola SQS"
-  value       = aws_sqs_queue.main.arn
+output "requests_queue_url" {
+  description = "URL de la cola SQS para solicitudes de descarga"
+  value       = aws_sqs_queue.download_requests.url
+}
+
+output "queues_arn" {
+  description = "ARNs de las colas SQS"
+  value       = [
+    aws_sqs_queue.download_status.arn,
+    aws_sqs_queue.download_requests.arn,
+  ]
 }

--- a/microservices/audio_processor/song-downloader-infra/terraform.example.tfvars
+++ b/microservices/audio_processor/song-downloader-infra/terraform.example.tfvars
@@ -7,6 +7,8 @@ service_timeout = 2
 youtube_api_key = ""
 container_port = 8080
 secret_name = "butakero-audio-service-secrets"
+ecs_service_desired_count = 1
+workers_count = 2
 
 alb_tags = {
   Project     = "music-downloader"

--- a/microservices/audio_processor/song-downloader-infra/variables.tf
+++ b/microservices/audio_processor/song-downloader-infra/variables.tf
@@ -10,6 +10,12 @@ variable "project_name" {
   default     = "music-downloader"
 }
 
+variable "workers_count" {
+  description = "Numero de workers para procesar cada evento"
+  type = number
+  default = 2
+}
+
 variable "environment" {
   description = "Ambiente de despliegue"
   type        = string

--- a/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
@@ -49,6 +49,11 @@ func (h *EventHandler) GuildCreate(ctx context.Context, _ *discordgo.Session, ev
 		return
 	}
 
+	if _, err := h.guildManager.GetGuildPlayer(event.Guild.ID); err == nil {
+		h.logger.Debug("GuildPlayer ya existe", zap.String("guildID", event.Guild.ID))
+		return
+	}
+
 	guildPlayer, err := h.guildManager.CreateGuildPlayer(event.Guild.ID)
 	if err != nil {
 		h.logger.Error("Error al crear GuildPlayer", zap.String("guildID", event.Guild.ID), zap.Error(err))

--- a/microservices/butakero_bot/internal/shared/config/config.go
+++ b/microservices/butakero_bot/internal/shared/config/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/secretmanager"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared"
 	"github.com/spf13/viper"
+	"math"
 	"strconv"
 	"time"
 )

--- a/microservices/butakero_bot/internal/shared/config/config.go
+++ b/microservices/butakero_bot/internal/shared/config/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/secretmanager"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared"
 	"github.com/spf13/viper"
+	"strconv"
 	"time"
 )
 
@@ -227,11 +228,22 @@ func LoadConfigAws() (*Config, error) {
 		QueueConfig: QueueConfig{
 			SQSConfig: SQSConfig{
 				Queues: &QueuesSQS{
-					BotDownloadRequestsQueueURL: secrets["QUEUE_BOT_DOWNLOAD_REQUESTS"],
-					BotDownloadStatusQueueURL:   secrets["QUEUE_BOT_DOWNLOAD_STATUS"],
+					BotDownloadRequestsQueueURL: secrets["SQS_BOT_DOWNLOAD_REQUESTS_URL"],
+					BotDownloadStatusQueueURL:   secrets["SQS_BOT_DOWNLOAD_STATUS_URL"],
 				},
+				MaxMessages:     int32(getSecretAsInt(secrets, "SQS_MAX_MESSAGES", 10)),
+				WaitTimeSeconds: int32(getSecretAsInt(secrets, "SQS_WAIT_TIME_SECONDS", 20)),
 			},
 		},
 	}
 	return cfg, nil
+}
+
+func getSecretAsInt(secrets map[string]string, key string, defaultValue int) int {
+	if valueStr, ok := secrets[key]; ok {
+		if value, err := strconv.Atoi(valueStr); err == nil {
+			return value
+		}
+	}
+	return defaultValue
 }

--- a/microservices/butakero_bot/internal/shared/config/config.go
+++ b/microservices/butakero_bot/internal/shared/config/config.go
@@ -231,18 +231,20 @@ func LoadConfigAws() (*Config, error) {
 					BotDownloadRequestsQueueURL: secrets["SQS_BOT_DOWNLOAD_REQUESTS_URL"],
 					BotDownloadStatusQueueURL:   secrets["SQS_BOT_DOWNLOAD_STATUS_URL"],
 				},
-				MaxMessages:     int32(getSecretAsInt(secrets, "SQS_MAX_MESSAGES", 10)),
-				WaitTimeSeconds: int32(getSecretAsInt(secrets, "SQS_WAIT_TIME_SECONDS", 20)),
+				MaxMessages:     getSecretAsInt(secrets, "SQS_MAX_MESSAGES", 10),
+				WaitTimeSeconds: getSecretAsInt(secrets, "SQS_WAIT_TIME_SECONDS", 20),
 			},
 		},
 	}
 	return cfg, nil
 }
 
-func getSecretAsInt(secrets map[string]string, key string, defaultValue int) int {
+func getSecretAsInt(secrets map[string]string, key string, defaultValue int32) int32 {
 	if valueStr, ok := secrets[key]; ok {
-		if value, err := strconv.Atoi(valueStr); err == nil {
-			return value
+		if value, err := strconv.ParseInt(valueStr, 10, 32); err == nil {
+			if value >= math.MinInt32 && value <= math.MaxInt32 {
+				return int32(value)
+			}
 		}
 	}
 	return defaultValue


### PR DESCRIPTION
- **Implement separate SQS queues for download requests and status updates:**  This change separates the SQS queue used for receiving download requests from the queue used for sending status updates. This allows for better management and scalability of the message processing. (Technical Impact: Requires infrastructure changes to create separate queues and update configuration.)
- **Avoid duplicate GuildPlayer creation:** This change prevents the creation of duplicate `GuildPlayer` instances in the Discord bot, ensuring that only one player instance exists per guild. (Technical impact: none)
- **Improve SQS configuration loading:**  This change updates the SQS configuration loading logic to retrieve SQS queue URLs, max messages and wait time seconds from AWS Secrets Manager and provides default values if they are not available and using a util function for parsing int. (Technical Impact: This makes the application more flexible and secure by centralizing configuration.)