### PR TITLE
refactor: Replace InteractionID with RequestID for improved clarity

### DIFF
--- a/microservices/audio_processor/internal/delivery/queue/processor/media_processor.go
+++ b/microservices/audio_processor/internal/delivery/queue/processor/media_processor.go
@@ -38,7 +38,7 @@ func (p *MediaProcessor) ProcessRequest(ctx context.Context, req *model.MediaReq
 	defer cancel()
 
 	log := p.logger.With(
-		zap.String("interaction_id", req.InteractionID),
+		zap.String("request_id", req.RequestID),
 		zap.String("user_id", req.UserID),
 	)
 
@@ -53,7 +53,7 @@ func (p *MediaProcessor) ProcessRequest(ctx context.Context, req *model.MediaReq
 		return err
 	}
 
-	if err := p.coreService.ProcessMedia(reqCtx, mediaDetails, req.UserID, req.InteractionID); err != nil {
+	if err := p.coreService.ProcessMedia(reqCtx, mediaDetails, req.UserID, req.RequestID); err != nil {
 		log.Error("Error al procesar media", zap.Error(err))
 		return err
 	}

--- a/microservices/audio_processor/internal/domain/model/media_request.go
+++ b/microservices/audio_processor/internal/domain/model/media_request.go
@@ -3,9 +3,9 @@ package model
 import "time"
 
 type MediaRequest struct {
-	InteractionID string    `json:"interaction_id"`
-	UserID        string    `json:"user_id"`
-	Song          string    `json:"song"`
-	ProviderType  string    `json:"provider_type"`
-	Timestamp     time.Time `json:"timestamp"`
+	RequestID    string    `json:"request_id"`
+	UserID       string    `json:"user_id"`
+	Song         string    `json:"song"`
+	ProviderType string    `json:"provider_type"`
+	Timestamp    time.Time `json:"timestamp"`
 }

--- a/microservices/audio_processor/internal/domain/model/message.go
+++ b/microservices/audio_processor/internal/domain/model/message.go
@@ -3,7 +3,7 @@ package model
 type (
 	MediaProcessingMessage struct {
 		UserID           string            `json:"user_id"`
-		InteractionID    string            `json:"interaction_id"`
+		RequestID        string            `json:"request_id"`
 		VideoID          string            `json:"video_id"`
 		FileData         *FileData         `json:"file_data"`
 		PlatformMetadata *PlatformMetadata `json:"platform_metadata"`

--- a/microservices/audio_processor/internal/domain/ports/services.go
+++ b/microservices/audio_processor/internal/domain/ports/services.go
@@ -31,7 +31,7 @@ type (
 	}
 
 	CoreService interface {
-		ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails, userID, interactionID string) error
+		ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails, userID, requestID string) error
 	}
 
 	OperationService interface {

--- a/microservices/audio_processor/internal/domain/service/core_service.go
+++ b/microservices/audio_processor/internal/domain/service/core_service.go
@@ -39,7 +39,7 @@ func NewCoreService(
 	}
 }
 
-func (s *coreService) ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails, userID, interactionID string) error {
+func (s *coreService) ProcessMedia(ctx context.Context, mediaDetails *model.MediaDetails, userID, requestID string) error {
 	log := s.logger.With(
 		zap.String("component", "CoreService"),
 		zap.String("method", "ProcessMedia"),
@@ -106,7 +106,7 @@ func (s *coreService) ProcessMedia(ctx context.Context, mediaDetails *model.Medi
 		}
 
 		message := &model.MediaProcessingMessage{
-			InteractionID:    interactionID,
+			RequestID:        requestID,
 			UserID:           userID,
 			VideoID:          media.VideoID,
 			FileData:         media.FileData,

--- a/microservices/audio_processor/internal/infrastructure/queue/kafka/kafka_consumer.go
+++ b/microservices/audio_processor/internal/infrastructure/queue/kafka/kafka_consumer.go
@@ -147,7 +147,7 @@ func (c *ConsumerKafka) consumeLoop(ctx context.Context, pc sarama.PartitionCons
 			}
 
 			log.Info("Mensaje procesado correctamente",
-				zap.String("interaction_id", request.InteractionID),
+				zap.String("request_id", request.RequestID),
 				zap.String("user_id", request.UserID),
 				zap.String("provider_type", request.ProviderType))
 

--- a/microservices/audio_processor/internal/infrastructure/queue/kafka/kafka_producer.go
+++ b/microservices/audio_processor/internal/infrastructure/queue/kafka/kafka_producer.go
@@ -85,8 +85,6 @@ func (p *ProducerKafka) Publish(ctx context.Context, msg *model.MediaProcessingM
 		zap.String("component", "ProducerKafka"),
 		zap.String("method", "Publish"),
 		zap.String("topic", p.config.Messaging.Kafka.Topics.BotDownloadStatus),
-		zap.String("video_id", msg.VideoID),
-		zap.String("status", msg.Status),
 	)
 
 	select {

--- a/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_consumer.go
+++ b/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_consumer.go
@@ -145,7 +145,7 @@ func (c *ConsumerSQS) receiveMessages(ctx context.Context, out chan<- *model.Med
 
 		log.Info("Mensaje SQS procesado correctamente",
 			zap.String("message_id", *msg.MessageId),
-			zap.String("interaction_id", req.InteractionID),
+			zap.String("request_id", req.RequestID),
 			zap.String("user_id", req.UserID),
 			zap.String("provider_type", req.ProviderType))
 

--- a/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_producer.go
+++ b/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_producer.go
@@ -48,10 +48,7 @@ func NewProducerSQS(cfgApplication *config.Config, log logger.Logger) (ports.Mes
 func (p *ProducerSQS) Publish(ctx context.Context, msg *model.MediaProcessingMessage) error {
 	log := p.logger.With(
 		zap.String("component", "sqs_producer"),
-		zap.String("method", "Publish"),
-		zap.String("video_id", msg.VideoID),
-		zap.String("status", msg.Status),
-	)
+		zap.String("method", "Publish"))
 
 	log.Debug("Serializando mensaje para publicar")
 	body, err := json.Marshal(msg)

--- a/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_service_integration_test.go
+++ b/microservices/audio_processor/internal/infrastructure/queue/sqs/sqs_service_integration_test.go
@@ -258,11 +258,11 @@ func TestConsumerSQS_GetRequestsChannel(t *testing.T) {
 	defer suite.tearDown()
 
 	testMsg := &model.MediaRequest{
-		InteractionID: "test-interaction-id",
-		UserID:        "test-user-id",
-		Song:          "test-song",
-		ProviderType:  "youtube",
-		Timestamp:     time.Now(),
+		RequestID:    "test-interaction-id",
+		UserID:       "test-user-id",
+		Song:         "test-song",
+		ProviderType: "youtube",
+		Timestamp:    time.Now(),
 	}
 
 	suite.sendMessageToQueue(testMsg)
@@ -273,7 +273,7 @@ func TestConsumerSQS_GetRequestsChannel(t *testing.T) {
 	select {
 	case receivedMsg := <-msgChan:
 		assert.NotNil(t, receivedMsg, "Mensaje recibido no debe ser nil")
-		assert.Equal(t, testMsg.InteractionID, receivedMsg.InteractionID)
+		assert.Equal(t, testMsg.RequestID, receivedMsg.RequestID)
 		assert.Equal(t, testMsg.UserID, receivedMsg.UserID)
 		assert.Equal(t, testMsg.Song, receivedMsg.Song)
 		assert.Equal(t, testMsg.ProviderType, receivedMsg.ProviderType)
@@ -301,11 +301,11 @@ func TestProducerConsumerIntegration(t *testing.T) {
 	}
 
 	mediaRequest := &model.MediaRequest{
-		InteractionID: "integration-test-interaction-id",
-		UserID:        "integration-test-user",
-		Song:          "integration-test-song",
-		ProviderType:  "youtube",
-		Timestamp:     time.Now(),
+		RequestID:    "integration-test-interaction-id",
+		UserID:       "integration-test-user",
+		Song:         "integration-test-song",
+		ProviderType: "youtube",
+		Timestamp:    time.Now(),
 	}
 
 	err := suite.producerSQS.Publish(suite.ctx, testMsg)
@@ -322,7 +322,7 @@ func TestProducerConsumerIntegration(t *testing.T) {
 	select {
 	case receivedMsg := <-msgChan:
 		assert.NotNil(t, receivedMsg, "Mensaje recibido no debe ser nil")
-		assert.Equal(t, mediaRequest.InteractionID, receivedMsg.InteractionID)
+		assert.Equal(t, mediaRequest.RequestID, receivedMsg.RequestID)
 		assert.Equal(t, mediaRequest.UserID, receivedMsg.UserID)
 		assert.Equal(t, mediaRequest.Song, receivedMsg.Song)
 		assert.Equal(t, mediaRequest.ProviderType, receivedMsg.ProviderType)
@@ -339,11 +339,11 @@ func TestLongPollConsumer(t *testing.T) {
 	assert.NoError(t, err, "Error al obtener canal de mensajes")
 
 	delayedMsg := &model.MediaRequest{
-		InteractionID: "delayed-test-id",
-		UserID:        "delayed-user",
-		Song:          "delayed-song",
-		ProviderType:  "delayed-provider",
-		Timestamp:     time.Now(),
+		RequestID:    "delayed-test-id",
+		UserID:       "delayed-user",
+		Song:         "delayed-song",
+		ProviderType: "delayed-provider",
+		Timestamp:    time.Now(),
 	}
 
 	go func() {
@@ -354,7 +354,7 @@ func TestLongPollConsumer(t *testing.T) {
 	select {
 	case receivedMsg := <-msgChan:
 		assert.NotNil(t, receivedMsg, "Mensaje recibido no debe ser nil")
-		assert.Equal(t, delayedMsg.InteractionID, receivedMsg.InteractionID)
+		assert.Equal(t, delayedMsg.RequestID, receivedMsg.RequestID)
 		assert.Equal(t, delayedMsg.UserID, receivedMsg.UserID)
 	case <-time.After(10 * time.Second):
 		assert.Fail(t, "Timeout esperando mensaje del canal (long polling)")

--- a/microservices/audio_processor/internal/logger/logger.go
+++ b/microservices/audio_processor/internal/logger/logger.go
@@ -24,26 +24,29 @@ type (
 
 func NewProductionLogger() (*ZapLogger, error) {
 	config := zap.NewProductionConfig()
-
 	config.DisableStacktrace = true
+
 	config.EncoderConfig = zapcore.EncoderConfig{
 		TimeKey:        "timestamp",
 		LevelKey:       "level",
 		NameKey:        "logger",
 		CallerKey:      "caller",
+		FunctionKey:    zapcore.OmitKey,
 		MessageKey:     "msg",
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
 		EncodeLevel:    zapcore.CapitalLevelEncoder,
 		EncodeTime:     customTimeEncoder,
 		EncodeDuration: zapcore.SecondsDurationEncoder,
-		EncodeCaller:   zapcore.ShortCallerEncoder,
+		EncodeCaller:   zapcore.FullCallerEncoder,
 	}
 
 	config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	config.Encoding = "json"
 
-	logger, err := config.Build()
+	logger, err := config.Build(
+		zap.AddCallerSkip(1),
+		zap.AddCaller())
 	if err != nil {
 		return nil, err
 	}

--- a/microservices/audio_processor/internal/worker/worker.go
+++ b/microservices/audio_processor/internal/worker/worker.go
@@ -35,10 +35,10 @@ func (w *Worker) Start(ctx context.Context, wg *sync.WaitGroup, requestChan <-ch
 				return
 			}
 
-			w.logger.Info("Procesando requests", zap.Int("worker_id", w.id), zap.String("interaction_id", req.InteractionID))
+			w.logger.Info("Procesando requests", zap.Int("worker_id", w.id), zap.String("requests_id", req.RequestID))
 
 			if err := w.processor.ProcessRequest(ctx, req); err != nil {
-				w.logger.Error("Error al procesar la solicitud", zap.Int("worker_id", w.id), zap.String("interaction_id", req.InteractionID), zap.Error(err))
+				w.logger.Error("Error al procesar la solicitud", zap.Int("worker_id", w.id), zap.String("requests_id", req.RequestID), zap.Error(err))
 			}
 		case <-ctx.Done():
 			w.logger.Info("Cerrando senal, finalizando worker", zap.Int("worker_id", w.id))

--- a/microservices/butakero_bot/internal/domain/entity/message_queue.go
+++ b/microservices/butakero_bot/internal/domain/entity/message_queue.go
@@ -4,7 +4,7 @@ import "time"
 
 type (
 	MessageQueue struct {
-		InteractionID    string   `json:"interaction_id"`
+		RequestID        string   `json:"request_id"`
 		UserID           string   `json:"user_id"`
 		VideoID          string   `json:"video_id"`
 		Message          string   `json:"message"`
@@ -29,10 +29,10 @@ type (
 	}
 
 	SongRequestMessage struct {
-		InteractionID string    `json:"interaction_id"`
-		UserID        string    `json:"user_id"`
-		Song          string    `json:"song"`
-		ProviderType  string    `json:"provider_type"`
-		Timestamp     time.Time `json:"timestamp"`
+		RequestID    string    `json:"request_id"`
+		UserID       string    `json:"user_id"`
+		Song         string    `json:"song"`
+		ProviderType string    `json:"provider_type"`
+		Timestamp    time.Time `json:"timestamp"`
 	}
 )

--- a/microservices/butakero_bot/internal/domain/ports/service.go
+++ b/microservices/butakero_bot/internal/domain/ports/service.go
@@ -14,6 +14,6 @@ type (
 	}
 
 	SongService interface {
-		GetOrDownloadSong(ctx context.Context, interactionID, userID, songInput, providerType string) (*entity.DiscordEntity, error)
+		GetOrDownloadSong(ctx context.Context, userID, songInput, providerType string) (*entity.DiscordEntity, error)
 	}
 )

--- a/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
@@ -49,7 +49,6 @@ func NewCommandHandler(
 
 func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.InteractionCreate, opt *discordgo.ApplicationCommandInteractionDataOption) {
 	userID := ic.Member.User.ID
-	interactionID := ic.ID
 
 	vs, ok := h.isUserInVoiceChannel(s, ic)
 	if !ok {
@@ -75,7 +74,7 @@ func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.Interactio
 	}
 
 	go func() {
-		song, err := h.songService.GetOrDownloadSong(context.Background(), interactionID, userID, input, "youtube")
+		song, err := h.songService.GetOrDownloadSong(context.Background(), userID, input, "youtube")
 		if err != nil {
 			h.logger.Error("Error al obtener canción", zap.Error(err))
 			if err := h.messenger.EditOriginalResponse(domainInteraction, &entity.WebhookEdit{

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -154,7 +154,7 @@ func (gp *GuildPlayer) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			gp.logger.Info("Cerrando el reproductor")
+			gp.logger.Debug("Cerrando el reproductor")
 			return nil
 
 		case event := <-gp.eventCh:

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer.go
@@ -70,7 +70,7 @@ func (p *ProducerKafka) PublishSongRequest(ctx context.Context, message *entity.
 		zap.String("component", "ProducerKafka"),
 		zap.String("method", "PublishSongRequest"),
 		zap.String("topic", p.cfg.QueueConfig.KafkaConfig.Topics.BotDownloadRequest),
-		zap.String("interaction_id", message.InteractionID),
+		zap.String("request_id", message.RequestID),
 	)
 
 	select {
@@ -87,7 +87,7 @@ func (p *ProducerKafka) PublishSongRequest(ctx context.Context, message *entity.
 
 	msg := &sarama.ProducerMessage{
 		Topic:     p.cfg.QueueConfig.KafkaConfig.Topics.BotDownloadRequest,
-		Key:       sarama.StringEncoder(message.InteractionID),
+		Key:       sarama.StringEncoder(message.RequestID),
 		Value:     sarama.ByteEncoder(jsonData),
 		Timestamp: time.Now(),
 	}
@@ -103,7 +103,7 @@ func (p *ProducerKafka) PublishSongRequest(ctx context.Context, message *entity.
 		log.Info("Mensaje publicado exitosamente",
 			zap.Int32("partition", partition),
 			zap.Int64("offset", offset),
-			zap.String("interaction_id", message.InteractionID))
+			zap.String("request_id", message.RequestID))
 		done <- nil
 	}()
 

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer_integration_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer_integration_test.go
@@ -129,11 +129,11 @@ func TestProducerKafka_PublishSongRequest(t *testing.T) {
 	}()
 
 	testMessage := &entity.SongRequestMessage{
-		InteractionID: "test-interaction-123",
-		UserID:        "user123",
-		Song:          "Despacito",
-		ProviderType:  "youtube",
-		Timestamp:     time.Now(),
+		RequestID:    "test-interaction-123",
+		UserID:       "user123",
+		Song:         "Despacito",
+		ProviderType: "youtube",
+		Timestamp:    time.Now(),
 	}
 
 	err = producer.PublishSongRequest(testContext, testMessage)
@@ -169,10 +169,10 @@ func TestProducerKafka_PublishSongRequest_ContextCancellation(t *testing.T) {
 
 	cancelCtx, cancel := context.WithCancel(testContext)
 	testMessage := &entity.SongRequestMessage{
-		InteractionID: "test-canceled-interaction",
-		UserID:        "user123",
-		ProviderType:  "youtube",
-		Timestamp:     time.Now(),
+		RequestID:    "test-canceled-interaction",
+		UserID:       "user123",
+		ProviderType: "youtube",
+		Timestamp:    time.Now(),
 	}
 
 	cancel()

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer.go
@@ -94,8 +94,8 @@ func (s *SQSConsumer) receiveAndProcessMessages(ctx context.Context) {
 
 func (s *SQSConsumer) handleMessage(ctx context.Context, msg types.Message) {
 	logger := s.logger.With(
+		zap.String("component", "SQSConsumer"),
 		zap.String("method", "handleMessage"),
-		zap.String("messageID", *msg.MessageId),
 	)
 
 	logger.Debug("Mensaje recibido")
@@ -128,6 +128,7 @@ func (s *SQSConsumer) GetMessagesChannel() <-chan *entity.MessageQueue {
 
 func (s *SQSConsumer) deleteMessage(ctx context.Context, msg types.Message) {
 	logger := s.logger.With(
+		zap.String("component", "SQSConsumer"),
 		zap.String("method", "deleteMessage"),
 		zap.String("messageID", *msg.MessageId),
 	)

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer.go
@@ -51,7 +51,6 @@ func (p *ProducerSQS) PublishSongRequest(ctx context.Context, message *entity.So
 		zap.String("component", "SQSProducer"),
 		zap.String("method", "PublishSongRequest"),
 		zap.String("queue_url", p.cfg.QueueConfig.SQSConfig.Queues.BotDownloadRequestsQueueURL),
-		zap.String("interaction_id", message.InteractionID),
 	)
 
 	select {
@@ -70,9 +69,9 @@ func (p *ProducerSQS) PublishSongRequest(ctx context.Context, message *entity.So
 		QueueUrl:    aws.String(p.cfg.QueueConfig.SQSConfig.Queues.BotDownloadRequestsQueueURL),
 		MessageBody: aws.String(string(jsonData)),
 		MessageAttributes: map[string]types.MessageAttributeValue{
-			"InteractionID": {
+			"RequestID": {
 				DataType:    aws.String("String"),
-				StringValue: aws.String(message.InteractionID),
+				StringValue: aws.String(message.RequestID),
 			},
 		},
 	}
@@ -86,7 +85,7 @@ func (p *ProducerSQS) PublishSongRequest(ctx context.Context, message *entity.So
 		}
 		log.Info("Mensaje publicado exitosamente",
 			zap.String("message_id", *resp.MessageId),
-			zap.String("interaction_id", message.InteractionID))
+			zap.String("interaction_id", message.RequestID))
 		done <- nil
 	}()
 

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer_integration_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer_integration_test.go
@@ -113,11 +113,11 @@ func TestProducerSQS_PublishSongRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	testMessage := &entity.SongRequestMessage{
-		InteractionID: "test-interaction-123",
-		UserID:        "user-456",
-		Song:          "Never Gonna Give You Up",
-		ProviderType:  "youtube",
-		Timestamp:     time.Now(),
+		RequestID:    "test-interaction-123",
+		UserID:       "user-456",
+		Song:         "Never Gonna Give You Up",
+		ProviderType: "youtube",
+		Timestamp:    time.Now(),
 	}
 
 	err = producer.PublishSongRequest(ctx, testMessage)
@@ -135,15 +135,15 @@ func TestProducerSQS_PublishSongRequest(t *testing.T) {
 	message := receiveResult.Messages[0]
 	assert.NotNil(t, message.MessageId, "Message ID should not be nil")
 
-	interactionID, ok := message.MessageAttributes["InteractionID"]
-	require.True(t, ok, "InteractionID attribute should exist")
-	assert.Equal(t, testMessage.InteractionID, *interactionID.StringValue)
+	interactionID, ok := message.MessageAttributes["RequestID"]
+	require.True(t, ok, "RequestID attribute should exist")
+	assert.Equal(t, testMessage.RequestID, *interactionID.StringValue)
 
 	var receivedMessage entity.SongRequestMessage
 	err = json.Unmarshal([]byte(*message.Body), &receivedMessage)
 	require.NoError(t, err)
 
-	assert.Equal(t, testMessage.InteractionID, receivedMessage.InteractionID)
+	assert.Equal(t, testMessage.RequestID, receivedMessage.RequestID)
 	assert.Equal(t, testMessage.UserID, receivedMessage.UserID)
 	assert.Equal(t, testMessage.Song, receivedMessage.Song)
 	assert.Equal(t, testMessage.ProviderType, receivedMessage.ProviderType)
@@ -189,11 +189,11 @@ func TestProducerSQS_PublishSongRequest_ContextCancelled(t *testing.T) {
 	}
 
 	testMessage := &entity.SongRequestMessage{
-		InteractionID: "test-interaction-123",
-		UserID:        "user-456",
-		Song:          "Never Gonna Give You Up",
-		ProviderType:  "youtube",
-		Timestamp:     time.Now(),
+		RequestID:    "test-interaction-123",
+		UserID:       "user-456",
+		Song:         "Never Gonna Give You Up",
+		ProviderType: "youtube",
+		Timestamp:    time.Now(),
 	}
 
 	cancelledCtx, cancel := context.WithCancel(ctx)

--- a/microservices/butakero_bot/internal/shared/logging/logger.go
+++ b/microservices/butakero_bot/internal/shared/logging/logger.go
@@ -53,26 +53,29 @@ func NewDevelopmentLogger() (*ZapLogger, error) {
 
 func NewProductionLogger() (*ZapLogger, error) {
 	config := zap.NewProductionConfig()
-
 	config.DisableStacktrace = true
+
 	config.EncoderConfig = zapcore.EncoderConfig{
 		TimeKey:        "timestamp",
 		LevelKey:       "level",
 		NameKey:        "logger",
 		CallerKey:      "caller",
+		FunctionKey:    zapcore.OmitKey,
 		MessageKey:     "msg",
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
 		EncodeLevel:    zapcore.CapitalLevelEncoder,
 		EncodeTime:     customTimeEncoder,
 		EncodeDuration: zapcore.SecondsDurationEncoder,
-		EncodeCaller:   zapcore.ShortCallerEncoder,
+		EncodeCaller:   zapcore.FullCallerEncoder,
 	}
 
 	config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	config.Encoding = "json"
 
-	logger, err := config.Build()
+	logger, err := config.Build(
+		zap.AddCallerSkip(1),
+		zap.AddCaller())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- **Rename `InteractionID` to `RequestID` in `MediaRequest` and related structures:** This change improves clarity by using a more descriptive and accurate name for the field, which represents the unique identifier for a processing request.
  -  Purpose: Enhance code readability and understanding.
  - Technical Impact: Requires updates across the codebase where the field was previously used.

- **Update logging statements to reflect the change from `InteractionID` to `RequestID`:** This ensures consistency in logging and makes it easier to track requests based on the new identifier.
  - Purpose: Improve log traceability and debugging capabilities.
  - Technical Impact:  Updates all logging instances.

- **Update the `GetOrDownloadSong` method in `butakero_bot` service:** Removes `interactionID` parameter, generates a `requestID` using UUID, and filters messages based on the new `requestID`. This centralizes request ID generation and simplifies the method signature.
  - Purpose:  Improve method's input parameters to remove unnecessary values.
  - Technical Impact: The method `GetOrDownloadSong` receives one parameter less, so calls to it need to align to the new input.