### PR TITLE
feat: Implement GetMediaByTitle functionality for media search

### DIFF
--- a/microservices/audio_processor/internal/domain/ports/media_repository.go
+++ b/microservices/audio_processor/internal/domain/ports/media_repository.go
@@ -10,8 +10,11 @@ type MediaRepository interface {
 	// SaveMedia guarda un registro de procesamiento multimedia.
 	SaveMedia(ctx context.Context, media *model.Media) error
 
-	// GetMedia obtiene un registro de procesamiento multimedia por su ID y video_id.
-	GetMedia(ctx context.Context, videoID string) (*model.Media, error)
+	// GetMediaByID obtiene un registro de procesamiento multimedia por su ID y video_id.
+	GetMediaByID(ctx context.Context, videoID string) (*model.Media, error)
+
+	// GetMediaByTitle obtiene un registro de procesamiento multimedia por su título.
+	GetMediaByTitle(ctx context.Context, title string) ([]*model.Media, error)
 
 	// DeleteMedia elimina un registro de procesamiento multimedia por su ID y video_id.
 	DeleteMedia(ctx context.Context, videoID string) error

--- a/microservices/audio_processor/internal/domain/ports/services.go
+++ b/microservices/audio_processor/internal/domain/ports/services.go
@@ -26,6 +26,7 @@ type (
 	MediaService interface {
 		CreateMedia(ctx context.Context, media *model.Media) error
 		GetMediaByID(ctx context.Context, videoID string) (*model.Media, error)
+		GetMediaByTitle(ctx context.Context, title string) ([]*model.Media, error)
 		UpdateMedia(ctx context.Context, videoID string, status *model.Media) error
 		DeleteMedia(ctx context.Context, videoID string) error
 	}

--- a/microservices/audio_processor/internal/domain/service/media_service.go
+++ b/microservices/audio_processor/internal/domain/service/media_service.go
@@ -26,7 +26,7 @@ func NewMediaService(repo ports.MediaRepository, logger logger.Logger) ports.Med
 
 func (s *mediaService) CreateMedia(ctx context.Context, media *model.Media) error {
 	log := s.logger.With(
-		zap.String("component", "MediaService"),
+		zap.String("component", "mediaService"),
 		zap.String("method", "CreateMedia"),
 	)
 
@@ -50,12 +50,12 @@ func (s *mediaService) CreateMedia(ctx context.Context, media *model.Media) erro
 
 func (s *mediaService) GetMediaByID(ctx context.Context, videoID string) (*model.Media, error) {
 	log := s.logger.With(
-		zap.String("component", "MediaService"),
+		zap.String("component", "mediaService"),
 		zap.String("method", "GetMediaByID"),
 		zap.String("video_id", videoID),
 	)
 
-	media, err := s.repo.GetMedia(ctx, videoID)
+	media, err := s.repo.GetMediaByID(ctx, videoID)
 	if err != nil {
 		log.Error("Error al obtener el registro de media", zap.Error(err))
 		return nil, err
@@ -66,7 +66,7 @@ func (s *mediaService) GetMediaByID(ctx context.Context, videoID string) (*model
 
 func (s *mediaService) UpdateMedia(ctx context.Context, videoID string, media *model.Media) error {
 	log := s.logger.With(
-		zap.String("component", "MediaService"),
+		zap.String("component", "mediaService"),
 		zap.String("method", "UpdateMedia"),
 		zap.String("video_id", videoID),
 	)
@@ -88,9 +88,26 @@ func (s *mediaService) UpdateMedia(ctx context.Context, videoID string, media *m
 	return nil
 }
 
+func (s *mediaService) GetMediaByTitle(ctx context.Context, title string) ([]*model.Media, error) {
+	log := s.logger.With(
+		zap.String("component", "mediaService"),
+		zap.String("method", "GetMediaByTitle"),
+		zap.String("title", title),
+	)
+
+	media, err := s.repo.GetMediaByTitle(ctx, title)
+	if err != nil {
+		log.Error("Error al obtener el registro de media", zap.Error(err))
+		return nil, err
+	}
+
+	log.Info("Registro de media obtenido exitosamente")
+	return media, nil
+}
+
 func (s *mediaService) DeleteMedia(ctx context.Context, videoID string) error {
 	log := s.logger.With(
-		zap.String("component", "MediaService"),
+		zap.String("component", "mediaService"),
 		zap.String("method", "DeleteMedia"),
 		zap.String("video_id", videoID),
 	)

--- a/microservices/audio_processor/internal/domain/service/media_service_test.go
+++ b/microservices/audio_processor/internal/domain/service/media_service_test.go
@@ -82,7 +82,7 @@ func TestMediaService_GetMediaByID(t *testing.T) {
 
 	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
 	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
-	mockRepo.On("GetMedia", mock.Anything, videoID).Return(expectedMedia, nil)
+	mockRepo.On("GetMediaByID", mock.Anything, videoID).Return(expectedMedia, nil)
 
 	// Act
 	media, err := service.GetMediaByID(context.Background(), videoID)
@@ -105,7 +105,7 @@ func TestMediaService_GetMediaByID_Error(t *testing.T) {
 
 	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
 	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
-	mockRepo.On("GetMedia", mock.Anything, videoID).Return(&model.Media{}, expectedError)
+	mockRepo.On("GetMediaByID", mock.Anything, videoID).Return(&model.Media{}, expectedError)
 
 	// Act
 	media, err := service.GetMediaByID(context.Background(), videoID)

--- a/microservices/audio_processor/internal/domain/service/mocks.go
+++ b/microservices/audio_processor/internal/domain/service/mocks.go
@@ -67,9 +67,14 @@ func (m *MockMediaRepository) SaveMedia(ctx context.Context, media *model.Media)
 	return args.Error(0)
 }
 
-func (m *MockMediaRepository) GetMedia(ctx context.Context, videoID string) (*model.Media, error) {
+func (m *MockMediaRepository) GetMediaByID(ctx context.Context, videoID string) (*model.Media, error) {
 	args := m.Called(ctx, videoID)
 	return args.Get(0).(*model.Media), args.Error(1)
+}
+
+func (m *MockMediaRepository) GetMediaByTitle(ctx context.Context, title string) ([]*model.Media, error) {
+	args := m.Called(ctx, title)
+	return args.Get(0).([]*model.Media), args.Error(1)
 }
 
 func (m *MockMediaRepository) DeleteMedia(ctx context.Context, videoID string) error {
@@ -109,6 +114,11 @@ func (m *MockMediaService) GetMediaByID(ctx context.Context, videoID string) (*m
 func (m *MockMediaService) UpdateMedia(ctx context.Context, videoID string, status *model.Media) error {
 	args := m.Called(ctx, videoID, status)
 	return args.Error(0)
+}
+
+func (m *MockMediaService) GetMediaByTitle(ctx context.Context, title string) ([]*model.Media, error) {
+	args := m.Called(ctx, title)
+	return args.Get(0).([]*model.Media), args.Error(1)
 }
 
 func (m *MockMediaService) DeleteMedia(ctx context.Context, videoID string) error {


### PR DESCRIPTION
- **Implemented `GetMediaByTitle` in MongoDB repository:** Adds the ability to search for media by title in the MongoDB repository using a regex case insensitive search.
- **Implemented `GetMediaByTitle` in DynamoDB repository:** Adds the ability to search for media by title in the DynamoDB repository, leveraging a Global Secondary Index (GSI) for efficient searching.
- **Added `GetMediaByTitle` method to `MediaService`:** This exposes the new search functionality at the service layer, enabling the API to search for media by title.