### PR TITLE
feat: Implement media search API and controller refactoring

### DIFF
--- a/microservices/audio_processor/cmd/aws/server/server.go
+++ b/microservices/audio_processor/cmd/aws/server/server.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/config"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/http/handler"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/http/controller"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/queue/processor"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/router"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/ports"
@@ -108,13 +108,14 @@ func StartServer() error {
 	coreService := service.NewCoreService(mediaService, audioStorageService, topicPublisherService, audioDownloadService, log, cfg)
 	operationService := service.NewOperationService(mediaService, log)
 	providerService := service.NewVideoService(providers, log)
-	healthCheck := handler.NewHealthHandler(cfg)
+	healthCheck := controller.NewHealthHandler(cfg)
+	mediaController := controller.NewMediaController(mediaService)
 
 	downloadService := processor.NewDownloadService(cfg.NumWorkers, sqsConsumer, mediaService, providerService, coreService, operationService, log)
 
 	gin.SetMode(cfg.GinConfig.Mode)
 	r := gin.New()
-	router.SetupRoutes(r, healthCheck, log)
+	router.SetupRoutes(r, healthCheck, mediaController, log)
 
 	srv := &http.Server{
 		Addr:    ":8080",

--- a/microservices/audio_processor/cmd/local/server/server.go
+++ b/microservices/audio_processor/cmd/local/server/server.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/config"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/http/handler"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/http/controller"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/queue/processor"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/router"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/ports"
@@ -112,14 +112,14 @@ func StartServer() error {
 	coreService := service.NewCoreService(mediaService, audioStorageService, topicPublisherService, audioDownloadService, log, cfg)
 	operationService := service.NewOperationService(mediaService, log)
 	providerService := service.NewVideoService(providers, log)
-
-	healthCheck := handler.NewHealthHandler(cfg)
+	healthCheck := controller.NewHealthHandler(cfg)
+	mediaController := controller.NewMediaController(mediaService)
 
 	downloadService := processor.NewDownloadService(cfg.NumWorkers, kafkaConsumer, mediaService, providerService, coreService, operationService, log)
 
 	gin.SetMode(cfg.GinConfig.Mode)
 	r := gin.New()
-	router.SetupRoutes(r, healthCheck, log)
+	router.SetupRoutes(r, healthCheck, mediaController, log)
 
 	srv := &http.Server{
 		Addr:    ":8080",

--- a/microservices/audio_processor/internal/delivery/http/controller/health_check.go
+++ b/microservices/audio_processor/internal/delivery/http/controller/health_check.go
@@ -1,4 +1,4 @@
-package handler
+package controller
 
 import (
 	"context"

--- a/microservices/audio_processor/internal/delivery/http/controller/media_controller.go
+++ b/microservices/audio_processor/internal/delivery/http/controller/media_controller.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/errors"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type MediaController struct {
+	mediaService ports.MediaService
+}
+
+func NewMediaController(mediaService ports.MediaService) *MediaController {
+	return &MediaController{mediaService: mediaService}
+}
+
+func (mc *MediaController) GetMediaByID(c *gin.Context) {
+	videoID := c.Query("video_id")
+
+	if videoID == "" {
+		_ = c.Error(errors.ErrInvalidInput.WithMessage("falta el parametro 'video_id'"))
+		return
+	}
+
+	if !isValidSongID(videoID) {
+		_ = c.Error(errors.ErrInvalidInput.WithMessage("video_id inválido"))
+		return
+	}
+
+	media, err := mc.mediaService.GetMediaByID(c.Request.Context(), videoID)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, media)
+}
+
+func (mc *MediaController) SearchMediaByTitle(c *gin.Context) {
+	title := c.Query("title")
+	if len(title) < 3 {
+		_ = c.Error(errors.ErrInvalidInput.WithMessage("el título debe tener al menos 3 caracteres"))
+		return
+	}
+
+	medias, err := mc.mediaService.GetMediaByTitle(c.Request.Context(), title)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data":    medias,
+		"success": true,
+	})
+}
+
+func isValidSongID(songID string) bool {
+	return len(songID) > 0 && len(songID) <= 100
+}

--- a/microservices/audio_processor/internal/delivery/router/routes.go
+++ b/microservices/audio_processor/internal/delivery/router/routes.go
@@ -1,14 +1,15 @@
 package router
 
 import (
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/http/handler"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/http/controller"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/delivery/http/middleware"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
 	"github.com/gin-gonic/gin"
 )
 
 func SetupRoutes(router *gin.Engine,
-	healthCheck *handler.HealthHandler,
+	healthCheck *controller.HealthHandler,
+	mediaController *controller.MediaController,
 	log logger.Logger) {
 
 	router.Use(middleware.LoggingMiddleware(log), middleware.ErrorHandlerMiddleware())
@@ -16,5 +17,7 @@ func SetupRoutes(router *gin.Engine,
 	api := router.Group("/api")
 	{
 		api.GET("/v1/health", healthCheck.HealthCheckHandler)
+		api.GET("/v1/media", mediaController.GetMediaByID)
+		api.GET("/v1/media/search", mediaController.SearchMediaByTitle)
 	}
 }

--- a/microservices/audio_processor/internal/domain/service/media_service.go
+++ b/microservices/audio_processor/internal/domain/service/media_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/errors"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
 	"go.uber.org/zap"
 	"strings"
@@ -95,7 +96,12 @@ func (s *mediaService) GetMediaByTitle(ctx context.Context, title string) ([]*mo
 		zap.String("title", title),
 	)
 
-	media, err := s.repo.GetMediaByTitle(ctx, title)
+	titleNormalized := normalizedTitle(title)
+	if titleNormalized == "" {
+		return nil, errors.ErrInvalidInput.WithMessage("El título no puede estar vacío")
+	}
+
+	media, err := s.repo.GetMediaByTitle(ctx, titleNormalized)
 	if err != nil {
 		log.Error("Error al obtener el registro de media", zap.Error(err))
 		return nil, err

--- a/microservices/audio_processor/internal/errors/errors.go
+++ b/microservices/audio_processor/internal/errors/errors.go
@@ -13,14 +13,12 @@ var (
 		"s3_invalid_file":              http.StatusBadRequest,
 		"local_invalid_file":           http.StatusBadRequest,
 		"provider_not_found":           http.StatusNotFound,
-		"operation_not_found":          http.StatusNotFound,
 		"media_not_found":              http.StatusNotFound,
 		"local_file_not_found":         http.StatusNotFound,
 		"youtube_api_error":            http.StatusServiceUnavailable,
 		"duplicate_record":             http.StatusConflict,
 		"get_media_details_failed":     http.StatusInternalServerError,
 		"update_media_failed":          http.StatusInternalServerError,
-		"publish_message_failed":       http.StatusInternalServerError,
 		"start_operation_failed":       http.StatusInternalServerError,
 		"search_video_id_failed":       http.StatusInternalServerError,
 		"get_video_details_failed":     http.StatusInternalServerError,
@@ -47,9 +45,7 @@ var (
 	ErrGetMediaDetailsFailed = NewAppError("get_media_details_failed", "Error al obtener detalles del media")
 
 	ErrDuplicateRecord           = NewAppError("duplicate_record", "El registro ya existe")
-	ErrOperationNotFound         = NewAppError("operation_not_found", "No se encontró la operación solicitada")
 	ErrUpdateMediaFailed         = NewAppError("update_media_failed", "Error al actualizar el media")
-	ErrPublishMessageFailed      = NewAppError("publish_message_failed", "Error al publicar el mensaje")
 	ErrCodeSearchVideoIDFailed   = NewAppError("search_video_id_failed", "Error al buscar el ID del video")
 	ErrCodeGetVideoDetailsFailed = NewAppError("get_video_details_failed", "Error al obtener detalles del video")
 


### PR DESCRIPTION
- **Introduces Media Search API:**  Adds two new endpoints, `/v1/media` for searching media by ID and `/v1/media/search` for searching media by title.  This allows users to retrieve media information.
- **Refactors HTTP Handlers to Controllers:** Renames and moves the `health_check.go` file from `internal/delivery/http/handler` to `internal/delivery/http/controller`. This change is for better architectural organization.
- **Adds MediaController:** Introduces a `MediaController` to handle media-related API requests, encapsulating the logic for retrieving media by ID and title. This separates concerns and improves code maintainability.