### PR TITLE
refactor: Sanitize song titles before storing audio files

### DIFF
--- a/microservices/audio_processor/internal/domain/service/audio_storage_service.go
+++ b/microservices/audio_processor/internal/domain/service/audio_storage_service.go
@@ -28,7 +28,8 @@ func (as *audioStorageService) StoreAudio(ctx context.Context, buffer *bytes.Buf
 		zap.String("method", "StoreAudio"),
 		zap.String("songName", songName),
 	)
-	keyName := fmt.Sprintf("%s%s", songName, ".dca")
+	songNameNormalized := normalizedTitle(songName)
+	keyName := fmt.Sprintf("%s%s", songNameNormalized, ".dca")
 
 	if err := as.storage.UploadFile(ctx, keyName, buffer); err != nil {
 		log.Error("Error al subir el archivo", zap.Error(err))

--- a/microservices/audio_processor/internal/domain/service/audio_storage_service_test.go
+++ b/microservices/audio_processor/internal/domain/service/audio_storage_service_test.go
@@ -21,7 +21,7 @@ func TestAudioStorageService_StoreAudio(t *testing.T) {
 
 	service := NewAudioStorageService(mockStorage, mockLogger)
 
-	songName := "test-song"
+	songName := "testsong"
 	keyName := fmt.Sprintf("%s%s", songName, ".dca")
 	buffer := bytes.NewBuffer([]byte("test audio data"))
 	expectedFileData := &model.FileData{
@@ -51,7 +51,7 @@ func TestAudioStorageService_StoreAudio_UploadError(t *testing.T) {
 
 	service := NewAudioStorageService(mockStorage, mockLogger)
 
-	songName := "test-song"
+	songName := "testsong"
 	keyName := fmt.Sprintf("%s%s", songName, ".dca")
 	buffer := bytes.NewBuffer([]byte("test audio data"))
 	expectedError := errors.New("upload failed")
@@ -80,7 +80,7 @@ func TestAudioStorageService_StoreAudio_MetadataError(t *testing.T) {
 
 	service := NewAudioStorageService(mockStorage, mockLogger)
 
-	songName := "test-song"
+	songName := "testsong"
 	keyName := fmt.Sprintf("%s%s", songName, ".dca")
 	buffer := bytes.NewBuffer([]byte("test audio data"))
 	expectedError := errors.New("metadata failed")

--- a/microservices/audio_processor/internal/domain/service/media_service_test.go
+++ b/microservices/audio_processor/internal/domain/service/media_service_test.go
@@ -175,6 +175,28 @@ func TestMediaService_UpdateMedia_Error(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
+func TestNormalizedTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Elimina barras", "test/title", "testtitle"},
+		{"Elimina puntos", "test.title", "testtitle"},
+		{"Elimina múltiples especiales", "test/title.with$special#chars", "testtitlewithspecialchars"},
+		{"Mantiene espacios", "test title", "test title"},
+		{"Convierte a minúsculas", "TEST Title", "test title"},
+		{"Elimina emojis", "test 😊 title", "test  title"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizedTitle(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestMediaService_DeleteMedia(t *testing.T) {
 	// Arrange
 	mockRepo := new(MockMediaRepository)


### PR DESCRIPTION
- **Introduces `normalizedTitle` function:** Cleans up song titles by removing slashes, periods, special characters, emojis, and converting to lowercase.
    - Purpose: Ensures consistent and valid file names for audio storage, preventing issues with special characters and potential security vulnerabilities.
    - Technical impact: Affects how audio files are named and stored in the audio storage service.
- **Implements sanitization in `StoreAudio`:** Calls `normalizedTitle` to sanitize the `songName` before creating the `keyName` used for storing the audio file.
    - Purpose: Applies the title sanitization logic before uploading to storage.
    - Technical impact: Changes the naming convention of audio files stored.
- **Adds unit tests for `normalizedTitle`:** Validates the functionality of the `normalizedTitle` function with various test cases.
    - Purpose: Ensures the sanitization logic works as expected.
    - Technical impact: Improves test coverage for the audio storage service.