### PR TITLE
feat: Integrate Media Client for Bot & Add omitempty Tags

### DIFF
--- a/microservices/audio_processor/internal/domain/model/media.go
+++ b/microservices/audio_processor/internal/domain/model/media.go
@@ -8,9 +8,9 @@ type (
 
 	// Media representa un modelo de procesamiento multimedia.
 	Media struct {
-		PK             string            `json:"-" bson:"-" dynamodbav:"PK"`
+		PK             string            `json:"pk,omitempty" bson:"-" dynamodbav:"PK"`
 		SK             string            `json:"-" bson:"-" dynamodbav:"SK"`
-		VideoID        string            `json:"video_id" bson:"_id" dynamodbav:"-"`
+		VideoID        string            `json:"video_id,omitempty" bson:"_id" dynamodbav:"-"`
 		TitleLower     string            `json:"title_lower" bson:"title_lower" dynamodbav:"title_lower"`
 		Status         string            `json:"status" bson:"status" dynamodbav:"status"`
 		Message        string            `json:"message" bson:"message" dynamodbav:"message"`

--- a/microservices/butakero_bot/internal/domain/model/api_responses.go
+++ b/microservices/butakero_bot/internal/domain/model/api_responses.go
@@ -1,0 +1,58 @@
+package model
+
+import "time"
+
+type MediaResponse struct {
+	Data    *Media `json:"data"`
+	Success bool   `json:"success"`
+}
+
+type MediaListResponse struct {
+	Data    []*Media `json:"data"`
+	Success bool     `json:"success"`
+}
+
+// ErrorResponse representa el formato estándar de errores
+type ErrorResponse struct {
+	Error   ErrorDetail `json:"error"`
+	Success bool        `json:"success"`
+}
+
+// ErrorDetail contiene los detalles del error
+type ErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	VideoID string `json:"video_id,omitempty"`
+}
+
+type (
+	Media struct {
+		PK             string    `json:"-"`
+		TitleLower     string    `json:"title_lower"`
+		Status         string    `json:"status"`
+		Message        string    `json:"message"`
+		Metadata       Metadata  `json:"metadata"`
+		FileData       FileData  `json:"file_data"`
+		ProcessingDate time.Time `json:"processing_date"`
+		Success        bool      `json:"success"`
+		Attempts       int       `json:"attempts"`
+		Failures       int       `json:"failures"`
+		CreatedAt      time.Time `json:"created_at"`
+		UpdatedAt      time.Time `json:"updated_at"`
+		PlayCount      int       `json:"play_count"`
+	}
+
+	FileData struct {
+		FilePath string `json:"file_path"`
+		FileSize string `json:"file_size"`
+		FileType string `json:"file_type"`
+	}
+
+	Metadata struct {
+		Title        string `json:"title"`
+		DurationMs   int64  `json:"duration_ms"`
+		URL          string `json:"url"`
+		ThumbnailURL string `json:"thumbnail_url"`
+		Platform     string `json:"platform"`
+	}
+)

--- a/microservices/butakero_bot/internal/domain/ports/media_client.go
+++ b/microservices/butakero_bot/internal/domain/ports/media_client.go
@@ -1,0 +1,11 @@
+package ports
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
+)
+
+type MediaClient interface {
+	GetMediaByID(ctx context.Context, videoID string) (*model.Media, error)
+	SearchMediaByTitle(ctx context.Context, title string) ([]*model.Media, error)
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/api/media_api_client.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/api/media_api_client.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/errors_app"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type AudioAPIClientConfig struct {
+	BaseURL         string
+	Timeout         time.Duration
+	MaxIdleConns    int
+	MaxConnsPerHost int
+}
+
+type MediaAPIClient struct {
+	baseURL    *url.URL
+	logger     logging.Logger
+	httpClient *http.Client
+}
+
+func NewMediaAPIClient(config AudioAPIClientConfig, logger logging.Logger) (*MediaAPIClient, error) {
+	if config.Timeout == 0 {
+		config.Timeout = 10 * time.Second
+	}
+
+	baseURL, err := url.Parse(config.BaseURL)
+	if err != nil {
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInvalidInput, "La URL base no es válida", err)
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:    config.MaxIdleConns,
+		MaxConnsPerHost: config.MaxConnsPerHost,
+		IdleConnTimeout: 90 * time.Second,
+	}
+
+	logger = logger.With(
+		zap.String("component", "audio_api_client"),
+		zap.String("baseURL", config.BaseURL),
+	)
+
+	return &MediaAPIClient{
+		baseURL: baseURL,
+		logger:  logger,
+		httpClient: &http.Client{
+			Timeout:   config.Timeout,
+			Transport: transport,
+		},
+	}, nil
+}
+
+func (c *MediaAPIClient) GetMediaByID(ctx context.Context, id string) (*model.Media, error) {
+	logger := c.logger.With(
+		zap.String("component", "MediaAPIClient"),
+		zap.String("method", "GetMediaByID"),
+		zap.String("id", id),
+	)
+
+	endpoint := c.baseURL.JoinPath("api/v1/media")
+
+	params := url.Values{}
+	params.Add("video_id", id)
+	endpoint.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		logger.Error("Error al crear la solicitud", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "Hubo un error al crear la solicitud", err)
+	}
+
+	logger.Debug("Consultando cancion", zap.String("endpoint", endpoint.String()))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		logger.Error("Error al realizar la solicitud", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "Hubo realizar la solicitud", err)
+	}
+
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.Error("Error al cerrar el body de la respuesta", zap.Error(closeErr))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Error al leer el cuerpo de la respuesta", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "Error al leer el cuerpo de la respuesta", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var apiError model.ErrorResponse
+		if err := json.Unmarshal(body, &apiError); err != nil {
+			logger.Error("Error al decodificar el error de API",
+				zap.Error(err),
+				zap.Int("statusCode", resp.StatusCode),
+				zap.String("responseBody", string(body)),
+			)
+			return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, fmt.Sprintf("Error en la solicitud (Código: %d)", resp.StatusCode), err)
+		}
+	}
+
+	var response model.MediaResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		logger.Error("Error al decodificar la respuesta", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "No se pudo decodificar la respuesta", err)
+	}
+
+	if !response.Success {
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "No se pudo obtener la canción", fmt.Errorf("error al obtener el media con el id: %s", id))
+	}
+
+	logger.Info("Cancion encontrada con exito",
+		zap.String("id", id),
+		zap.String("title", response.Data.Metadata.Title),
+	)
+
+	return response.Data, nil
+
+}
+
+func (c *MediaAPIClient) SearchMediaByTitle(ctx context.Context, title string) ([]*model.Media, error) {
+	logger := c.logger.With(
+		zap.String("component", "MediaAPIClient"),
+		zap.String("method", "SearchMediaByTitle"),
+		zap.String("title", title),
+	)
+
+	endpoint := c.baseURL.JoinPath("api/v1/media/search")
+
+	params := url.Values{}
+	params.Add("title", title)
+	endpoint.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		logger.Error("Error al crear la solicitud", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "Hubo un error al crear la solicitud", err)
+	}
+
+	logger.Debug("Consultando cancion", zap.String("endpoint", endpoint.String()))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		logger.Error("Error al realizar la solicitud", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "Hubo realizar la solicitud", err)
+	}
+
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.Error("Error al cerrar el body de la respuesta", zap.Error(closeErr))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Error al leer el cuerpo de la respuesta", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "Error al leer el cuerpo de la respuesta", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, fmt.Sprintf("Error en la solicitud (Código: %d)", resp.StatusCode), err)
+	}
+
+	var response model.MediaListResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		logger.Error("Error al decodificar la respuesta", zap.Error(err))
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "No se pudo decodificar la respuesta", err)
+	}
+
+	if !response.Success {
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInternalError, "No se pudo obtener la canción", fmt.Errorf("error al obtener la cancion con el titulo: %s", title))
+	}
+
+	logger.Info("Cancion con el titulo encontrado con exito",
+		zap.String("title", response.Data[0].Metadata.Title),
+	)
+
+	return response.Data, nil
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/api/media_api_client_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/api/media_api_client_test.go
@@ -1,0 +1,338 @@
+//go:build !integration
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/errors_app"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestNewMediaAPIClient(t *testing.T) {
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+
+	cfg := AudioAPIClientConfig{
+		BaseURL:         "http://localhost",
+		Timeout:         time.Second * 5,
+		MaxConnsPerHost: 5,
+		MaxIdleConns:    10,
+	}
+
+	// act
+	client, err := NewMediaAPIClient(cfg, mockLogger)
+
+	// assert
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, "http://localhost", client.baseURL.String())
+	assert.Equal(t, 5*time.Second, client.httpClient.Timeout)
+}
+
+func TestNewMediaAPIClient_InvalidURL(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+
+	config := AudioAPIClientConfig{
+		BaseURL: "://invalid-url",
+	}
+
+	// Act
+	client, err := NewMediaAPIClient(config, mockLogger)
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "La URL base no es válida")
+}
+
+func TestGetMediaByID_Success(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/media", r.URL.Path)
+		assert.Equal(t, "test123", r.URL.Query().Get("video_id"))
+
+		media := &model.Media{
+			Status: "completed",
+			Metadata: model.Metadata{
+				Title:        "Test Song",
+				DurationMs:   180000,
+				URL:          "https://example.com/test123",
+				ThumbnailURL: "https://example.com/thumbnail.jpg",
+				Platform:     "youtube",
+			},
+			FileData: model.FileData{
+				FilePath: "/path/to/file",
+				FileSize: "10MB",
+				FileType: "mp3",
+			},
+			Success:   true,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		response := model.MediaResponse{
+			Data:    media,
+			Success: true,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	baseURL, _ := url.Parse(server.URL)
+	client := &MediaAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: server.Client(),
+	}
+
+	// Act
+	result, err := client.GetMediaByID(context.Background(), "test123")
+
+	// Assert
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "Test Song", result.Metadata.Title)
+	assert.Equal(t, "completed", result.Status)
+	assert.Equal(t, true, result.Success)
+}
+
+func TestGetMediaByID_NotFound(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/media", r.URL.Path)
+		assert.Equal(t, "nonexistent", r.URL.Query().Get("video_id"))
+
+		errorResp := model.ErrorResponse{
+			Error: model.ErrorDetail{
+				Code:    "media_not_found",
+				Message: "Media no encontrado",
+				VideoID: "nonexistent",
+			},
+			Success: false,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		err := json.NewEncoder(w).Encode(errorResp)
+		if err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	baseURL, _ := url.Parse(server.URL)
+	client := &MediaAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: server.Client(),
+	}
+
+	// Act
+	result, err := client.GetMediaByID(context.Background(), "nonexistent")
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "No se pudo obtener la canción")
+}
+
+func TestGetMediaByID_ServerError(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	baseURL, _ := url.Parse(server.URL)
+	client := &MediaAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: server.Client(),
+	}
+
+	// Act
+	result, err := client.GetMediaByID(context.Background(), "test123")
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, result)
+	var appErr *errors_app.AppError
+	ok := errors.As(err, &appErr)
+	assert.True(t, ok)
+	assert.Equal(t, errors_app.ErrCodeInternalError, appErr.Code)
+}
+
+func TestSearchMediaByTitle_Success(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/media/search", r.URL.Path)
+		assert.Equal(t, "test song", r.URL.Query().Get("title"))
+
+		media1 := &model.Media{
+			Status: "completed",
+			Metadata: model.Metadata{
+				Title:        "Test Song 1",
+				DurationMs:   180000,
+				URL:          "https://example.com/test1",
+				ThumbnailURL: "https://example.com/thumbnail1.jpg",
+				Platform:     "youtube",
+			},
+			Success: true,
+		}
+
+		media2 := &model.Media{
+			Status: "completed",
+			Metadata: model.Metadata{
+				Title:        "Test Song 2",
+				DurationMs:   240000,
+				URL:          "https://example.com/test2",
+				ThumbnailURL: "https://example.com/thumbnail2.jpg",
+				Platform:     "youtube",
+			},
+			Success: true,
+		}
+
+		response := model.MediaListResponse{
+			Data:    []*model.Media{media1, media2},
+			Success: true,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	baseURL, _ := url.Parse(server.URL)
+	client := &MediaAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: server.Client(),
+	}
+
+	// Act
+	results, err := client.SearchMediaByTitle(context.Background(), "test song")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, "Test Song 1", results[0].Metadata.Title)
+	assert.Equal(t, "Test Song 2", results[1].Metadata.Title)
+}
+
+func TestSearchMediaByTitle_NoResults(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/media/search", r.URL.Path)
+		assert.Equal(t, "nonexistent", r.URL.Query().Get("title"))
+
+		response := model.MediaListResponse{
+			Data:    []*model.Media{},
+			Success: false,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	baseURL, _ := url.Parse(server.URL)
+	client := &MediaAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: server.Client(),
+	}
+
+	// Act
+	results, err := client.SearchMediaByTitle(context.Background(), "nonexistent")
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, results)
+	var appErr *errors_app.AppError
+	ok := errors.As(err, &appErr)
+	assert.True(t, ok)
+	assert.Equal(t, errors_app.ErrCodeInternalError, appErr.Code)
+}
+
+func TestSearchMediaByTitle_ServerError(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	baseURL, _ := url.Parse(server.URL)
+	client := &MediaAPIClient{
+		baseURL:    baseURL,
+		logger:     mockLogger,
+		httpClient: server.Client(),
+	}
+
+	// Act
+	results, err := client.SearchMediaByTitle(context.Background(), "test song")
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, results)
+	var appErr *errors_app.AppError
+	ok := errors.As(err, &appErr)
+	assert.True(t, ok)
+	assert.Equal(t, errors_app.ErrCodeInternalError, appErr.Code)
+}


### PR DESCRIPTION
- **Add `omitempty` tag to PK and VideoID fields in `Media` struct (audio_processor):**  Prevents these fields from being included in JSON output when they are empty, improving data handling efficiency.
- **Define `MediaClient` interface and related models (butakero_bot):** Defines a contract for interacting with the media service, including `GetMediaByID` and `SearchMediaByTitle` methods. This is a foundation for abstraction and testability.
- **Implement `MediaAPIClient` (butakero_bot):** Provides an HTTP client to consume the media service API, allowing the bot to fetch media information by ID or search by title.