### PR TITLE
refactor: Move Discord messenger to subpackage and enhance GuildManager errors

### DIFF
--- a/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/command"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/events"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/messenger"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/storage"
 	sqsApp "github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/messaging/sqs"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/storage/s3_storage"
@@ -78,7 +79,7 @@ func StartBot() error {
 		return fmt.Errorf("error en el almacenamiento S3: %v", err)
 	}
 
-	discordMessenger := discord.NewDiscordMessengerAdapter(discordClient, logger)
+	discordMessenger := messenger.NewDiscordMessengerAdapter(discordClient, logger)
 	interactionStorage := storage.NewInMemoryInteractionStorage(logger)
 
 	mediaClient, err := api.NewMediaAPIClient(api.AudioAPIClientConfig{

--- a/microservices/butakero_bot/cmd/bot_local/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_local/bot/bot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/command"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/events"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/messenger"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/storage"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/messaging/kafka"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/storage/local"
@@ -82,7 +83,7 @@ func StartBot() error {
 		return fmt.Errorf("error al crear el cliente de Discord: %v", err)
 	}
 
-	discordMessenger := discord.NewDiscordMessengerAdapter(discordClient, logger)
+	discordMessenger := messenger.NewDiscordMessengerAdapter(discordClient, logger)
 	storageAudio := local_storage.NewLocalStorage(logger)
 	interactionStorage := storage.NewInMemoryInteractionStorage(logger)
 

--- a/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
@@ -49,14 +49,9 @@ func (h *EventHandler) GuildCreate(ctx context.Context, _ *discordgo.Session, ev
 		return
 	}
 
-	if _, err := h.guildManager.GetGuildPlayer(event.ID); err == nil {
-		h.logger.Debug("GuildPlayer ya existe", zap.String("guildID", event.ID))
-		return
-	}
-
-	guildPlayer, err := h.guildManager.CreateGuildPlayer(event.ID)
+	guildPlayer, err := h.guildManager.GetGuildPlayer(event.ID)
 	if err != nil {
-		h.logger.Error("Error al crear GuildPlayer", zap.String("guildID", event.ID), zap.Error(err))
+		h.logger.Error("Error al obtener GuildPlayer", zap.String("guildID", event.ID), zap.Error(err))
 		return
 	}
 

--- a/microservices/butakero_bot/internal/infrastructure/discord/guild_manager_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/guild_manager_test.go
@@ -1,0 +1,229 @@
+package discord
+
+import (
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/errors_app"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestNewGuildManager(t *testing.T) {
+	// Arrange
+	mockFactory := new(MockPlayerFactory)
+	mockLogger := new(logging.MockLogger)
+
+	// Act
+	manager := NewGuildManager(mockFactory, mockLogger)
+
+	// Assert
+	assert.NotNil(t, manager)
+	assert.IsType(t, &GuildManager{}, manager)
+}
+
+func TestCreateGuildPlayer_Success(t *testing.T) {
+	// Arrange
+	mockFactory := new(MockPlayerFactory)
+	mockLogger := new(logging.MockLogger)
+	manager := NewGuildManager(mockFactory, mockLogger)
+
+	guildID := "test-guild"
+	mockPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockFactory.On("CreatePlayer", guildID).Return(mockPlayer, nil)
+
+	// Act
+	player, err := manager.CreateGuildPlayer(guildID)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, player)
+	mockFactory.AssertExpectations(t)
+	mockPlayer.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCreateGuildPlayer_EmptyGuildID(t *testing.T) {
+	// Arrange
+	mockFactory := new(MockPlayerFactory)
+	mockLogger := new(logging.MockLogger)
+	manager := NewGuildManager(mockFactory, mockLogger)
+
+	// Act
+	player, err := manager.CreateGuildPlayer("")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Nil(t, player)
+	assert.Equal(t, errors_app.ErrCodeInvalidGuildID, err.(*errors_app.AppError).Code)
+}
+
+func TestGuildManager_CreateGuildPlayer_AlreadyExists(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	mockGuildPlayer := new(MockGuildPlayer)
+	mockPlayerFactory := new(MockPlayerFactory)
+	mockPlayerFactory.On("CreatePlayer", "guild123").Return(mockGuildPlayer, nil)
+
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	firstPlayer, err := guildManager.CreateGuildPlayer("guild123")
+	assert.NoError(t, err)
+	assert.NotNil(t, firstPlayer)
+
+	mockPlayerFactory.Calls = nil
+
+	secondPlayer, err := guildManager.CreateGuildPlayer("guild123")
+
+	assert.Error(t, err)
+	assert.True(t, errors_app.IsAppError(err), "El error debería ser un AppError")
+	assert.Equal(t, errors_app.ErrCodeGuildPlayerAlreadyExists, err.(*errors_app.AppError).Code)
+	assert.Equal(t, firstPlayer, secondPlayer)
+	mockPlayerFactory.AssertNotCalled(t, "CreatePlayer")
+}
+
+func TestGuildManager_CreateGuildPlayer_FactoryError(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	factoryError := errors_app.NewAppError(errors_app.ErrCodeInternalError, "Factory error", nil)
+	mockPlayerFactory := &MockPlayerFactory{}
+	mockPlayerFactory.On("CreatePlayer", "guild123").Return((*MockGuildPlayer)(nil), factoryError)
+
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	// Act
+	player, err := guildManager.CreateGuildPlayer("guild123")
+
+	// Assert
+	assert.Nil(t, player)
+	assert.Error(t, err)
+	assert.True(t, errors_app.IsAppError(err), "El error debería ser un AppError")
+	assert.Equal(t, errors_app.ErrCodeGuildPlayerCreateFailed, err.(*errors_app.AppError).Code)
+	mockPlayerFactory.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestGuildManager_RemoveGuildPlayer(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	mockGuildPlayer := new(MockGuildPlayer)
+	mockPlayerFactory := new(MockPlayerFactory)
+	mockPlayerFactory.On("CreatePlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockPlayerFactory.On("CreatePlayer", "guild123").Return(mockGuildPlayer, nil)
+
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	_, err := guildManager.CreateGuildPlayer("guild123")
+	assert.NoError(t, err)
+
+	// Act
+	err = guildManager.RemoveGuildPlayer("guild123")
+
+	// Assert
+	assert.NoError(t, err)
+	mockLogger.AssertExpectations(t)
+
+	_, err = guildManager.GetGuildPlayer("guild123")
+	assert.NoError(t, err)
+	mockPlayerFactory.AssertNumberOfCalls(t, "CreatePlayer", 2)
+}
+
+func TestGuildManager_RemoveGuildPlayer_EmptyGuildID(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockPlayerFactory := new(MockPlayerFactory)
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	// Act
+	err := guildManager.RemoveGuildPlayer("")
+
+	// Assert
+	assert.Error(t, err)
+	assert.True(t, errors_app.IsAppError(err), "El error debería ser un AppError")
+	assert.Equal(t, errors_app.ErrCodeInvalidGuildID, err.(*errors_app.AppError).Code)
+}
+
+func TestGuildManager_RemoveGuildPlayer_NotFound(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+
+	mockPlayerFactory := new(MockPlayerFactory)
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	// Act
+	err := guildManager.RemoveGuildPlayer("nonexistent")
+
+	// Assert
+	assert.Error(t, err)
+	assert.True(t, errors_app.IsAppError(err), "El error debería ser un AppError")
+	assert.Equal(t, errors_app.ErrCodeGuildPlayerNotFound, err.(*errors_app.AppError).Code)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestGuildManager_GetGuildPlayer_Existing(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	mockGuildPlayer := new(MockGuildPlayer)
+	mockPlayerFactory := new(MockPlayerFactory)
+	mockPlayerFactory.On("CreatePlayer", "guild123").Return(mockGuildPlayer, nil)
+
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	_, err := guildManager.CreateGuildPlayer("guild123")
+	assert.NoError(t, err)
+
+	// Act
+	player, err := guildManager.GetGuildPlayer("guild123")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, mockGuildPlayer, player)
+	mockPlayerFactory.AssertNumberOfCalls(t, "CreatePlayer", 1)
+}
+
+func TestGuildManager_GetGuildPlayer_NonExisting(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	mockGuildPlayer := new(MockGuildPlayer)
+	mockPlayerFactory := new(MockPlayerFactory)
+	mockPlayerFactory.On("CreatePlayer", "guild123").Return(mockGuildPlayer, nil)
+
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	// Act
+	player, err := guildManager.GetGuildPlayer("guild123")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, mockGuildPlayer, player)
+	mockPlayerFactory.AssertCalled(t, "CreatePlayer", "guild123")
+}
+
+func TestGuildManager_GetGuildPlayer_EmptyGuildID(t *testing.T) {
+	// Arrange
+	mockLogger := new(logging.MockLogger)
+	mockPlayerFactory := new(MockPlayerFactory)
+	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
+
+	// Act
+	player, err := guildManager.GetGuildPlayer("")
+
+	// Assert
+	assert.Nil(t, player)
+	assert.Error(t, err)
+	assert.True(t, errors_app.IsAppError(err), "El error debería ser un AppError")
+	assert.Equal(t, errors_app.ErrCodeInvalidGuildID, err.(*errors_app.AppError).Code)
+	mockPlayerFactory.AssertNotCalled(t, "CreatePlayer")
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/messenger/messenger.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/messenger/messenger.go
@@ -1,9 +1,10 @@
-package discord
+package messenger
 
 import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model/discord"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	discord2 "github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
 	"github.com/bwmarrin/discordgo"
 	"go.uber.org/zap"
@@ -34,7 +35,7 @@ func (m *DiscordMessengerAdapter) RespondWithMessage(interaction *discord.Intera
 }
 
 func (m *DiscordMessengerAdapter) SendPlayStatus(channelID string, playMsg *entity.PlayedSong) (string, error) {
-	embed := toDiscordgoEmbed(GeneratePlayingSongEmbed(playMsg))
+	embed := toDiscordgoEmbed(discord2.GeneratePlayingSongEmbed(playMsg))
 	msg, err := m.session.ChannelMessageSendEmbed(channelID, embed)
 	if err != nil {
 		m.logger.Error("Error al enviar estado de reproducción", zap.Error(err))
@@ -44,7 +45,7 @@ func (m *DiscordMessengerAdapter) SendPlayStatus(channelID string, playMsg *enti
 }
 
 func (m *DiscordMessengerAdapter) UpdatePlayStatus(channelID, messageID string, playMsg *entity.PlayedSong) error {
-	embed := toDiscordgoEmbed(GeneratePlayingSongEmbed(playMsg))
+	embed := toDiscordgoEmbed(discord2.GeneratePlayingSongEmbed(playMsg))
 	_, err := m.session.ChannelMessageEditEmbed(channelID, messageID, embed)
 	if err != nil {
 		m.logger.Error("Error al actualizar estado de reproducción", zap.Error(err))

--- a/microservices/butakero_bot/internal/infrastructure/discord/mocks.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/mocks.go
@@ -1,0 +1,109 @@
+package discord
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockPlayerFactory struct {
+	mock.Mock
+}
+
+func (m *MockPlayerFactory) CreatePlayer(guildID string) (ports.GuildPlayer, error) {
+	args := m.Called(guildID)
+	return args.Get(0).(ports.GuildPlayer), args.Error(1)
+}
+
+type MockGuildPlayer struct {
+	mock.Mock
+}
+
+func (m *MockGuildPlayer) Run(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) Stop() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) Pause() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) Resume() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) SkipSong() {
+	m.Called()
+}
+
+func (m *MockGuildPlayer) AddSong(textChannelID, voiceChannelID *string, playedSong *entity.PlayedSong) error {
+	args := m.Called(textChannelID, voiceChannelID, playedSong)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) RemoveSong(position int) (*entity.DiscordEntity, error) {
+	args := m.Called(position)
+	return args.Get(0).(*entity.DiscordEntity), args.Error(1)
+}
+
+func (m *MockGuildPlayer) GetPlaylist() ([]string, error) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockGuildPlayer) GetPlayedSong() (*entity.PlayedSong, error) {
+	args := m.Called()
+	return args.Get(0).(*entity.PlayedSong), args.Error(1)
+}
+
+func (m *MockGuildPlayer) StateStorage() ports.StateStorage {
+	args := m.Called()
+	return args.Get(0).(ports.StateStorage)
+}
+
+func (m *MockGuildPlayer) JoinVoiceChannel(channelID string) error {
+	args := m.Called(channelID)
+	return args.Error(0)
+}
+
+type MockStateStorage struct {
+	mock.Mock
+}
+
+func (m *MockStateStorage) SetVoiceChannel(channelID string) error {
+	args := m.Called(channelID)
+	return args.Error(0)
+}
+
+func (m *MockStateStorage) GetVoiceChannel() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockStateStorage) SetTextChannel(channelID string) error {
+	args := m.Called(channelID)
+	return args.Error(0)
+}
+
+func (m *MockStateStorage) GetTextChannel() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockStateStorage) SetCurrentSong(song *entity.PlayedSong) error {
+	args := m.Called(song)
+	return args.Error(0)
+}
+
+func (m *MockStateStorage) GetCurrentSong() (*entity.PlayedSong, error) {
+	args := m.Called()
+	return args.Get(0).(*entity.PlayedSong), args.Error(1)
+}

--- a/microservices/butakero_bot/internal/shared/errors_app/errors.go
+++ b/microservices/butakero_bot/internal/shared/errors_app/errors.go
@@ -9,13 +9,11 @@ import (
 type ErrorCode string
 
 const (
-	// Errores generales
 	ErrCodeInternalError   ErrorCode = "internal_error"
 	ErrCodeInvalidInput    ErrorCode = "invalid_input"
 	ErrCodeInvalidVideoID  ErrorCode = "invalid_video_id"
 	ErrCodeInvalidMetadata ErrorCode = "invalid_metadata"
 
-	// Errores relacionados con la API externa
 	ErrCodeProviderNotFound      ErrorCode = "provider_not_found"
 	ErrCodeYouTubeAPIError       ErrorCode = "youtube_api_error"
 	ErrCodeAPIDuplicateRecord    ErrorCode = "duplicate_record"
@@ -31,7 +29,6 @@ const (
 	ErrCodeGetVideoDetailsFailed ErrorCode = "get_video_details_failed"
 	ErrCodeGetMediaDetailsFailed ErrorCode = "get_media_details_failed"
 
-	// Errores relacionados con almacenamiento
 	ErrCodeS3UploadFailed            ErrorCode = "s3_upload_failed"
 	ErrCodeS3GetMetadataFailed       ErrorCode = "s3_get_metadata_failed"
 	ErrCodeS3GetContentFailed        ErrorCode = "s3_get_content_failed"
@@ -46,18 +43,13 @@ const (
 	ErrCodeDeleteMediaFailed         ErrorCode = "delete_media_failed"
 	ErrCodeGetMediaFailed            ErrorCode = "get_media_failed"
 
-	// Errores relacionados con yt-dlp
 	ErrCodeYTDLPCommandFailed ErrorCode = "ytdlp_command_failed"
 	ErrCodeYTDLPInvalidOutput ErrorCode = "ytdlp_invalid_output"
 
-	// Errores relacionados con Discord
-	ErrCodeDiscordNotInVoiceChannel ErrorCode = "discord_not_in_voice_channel"
-	ErrCodeDiscordFailedToAddSong   ErrorCode = "discord_failed_to_add_song"
 	ErrCodeGuildPlayerNotFound      ErrorCode = "guild_player_not_found"
-
-	// Errores relacionados con la base de datos
-	ErrCodeDBConnectionFailed ErrorCode = "db_connection_failed"
-	ErrCodeDBRecordNotFound   ErrorCode = "db_record_not_found"
+	ErrCodeInvalidGuildID           ErrorCode = "invalid_guild_id"
+	ErrCodeGuildPlayerAlreadyExists ErrorCode = "guild_player_already_exists"
+	ErrCodeGuildPlayerCreateFailed  ErrorCode = "guild_player_create_failed"
 )
 
 var errorStatusMap = map[ErrorCode]int{
@@ -73,7 +65,6 @@ var errorStatusMap = map[ErrorCode]int{
 	ErrCodeOperationNotFound: http.StatusNotFound,
 	ErrCodeMediaNotFound:     http.StatusNotFound,
 	ErrCodeLocalFileNotFound: http.StatusNotFound,
-	ErrCodeDBRecordNotFound:  http.StatusNotFound,
 
 	// 409 Conflict
 	ErrCodeAPIDuplicateRecord: http.StatusConflict,
@@ -92,7 +83,6 @@ var errorStatusMap = map[ErrorCode]int{
 	ErrCodeSearchVideoIDFailed:       http.StatusInternalServerError,
 	ErrCodeGetVideoDetailsFailed:     http.StatusInternalServerError,
 	ErrCodeGetMediaDetailsFailed:     http.StatusInternalServerError,
-	ErrCodeDBConnectionFailed:        http.StatusInternalServerError,
 	ErrCodeSaveMediaFailed:           http.StatusInternalServerError,
 	ErrCodeDeleteMediaFailed:         http.StatusInternalServerError,
 	ErrCodeGetMediaFailed:            http.StatusInternalServerError,
@@ -105,9 +95,10 @@ var errorStatusMap = map[ErrorCode]int{
 	ErrCodeLocalDirectoryNotWritable: http.StatusInternalServerError,
 	ErrCodeYTDLPCommandFailed:        http.StatusInternalServerError,
 	ErrCodeYTDLPInvalidOutput:        http.StatusInternalServerError,
-	ErrCodeDiscordNotInVoiceChannel:  http.StatusInternalServerError,
-	ErrCodeDiscordFailedToAddSong:    http.StatusInternalServerError,
-	ErrCodeGuildPlayerNotFound:       http.StatusInternalServerError,
+	ErrCodeGuildPlayerNotFound:       http.StatusNotFound,
+	ErrCodeInvalidGuildID:            http.StatusBadRequest,
+	ErrCodeGuildPlayerCreateFailed:   http.StatusInternalServerError,
+	ErrCodeGuildPlayerAlreadyExists:  http.StatusConflict,
 }
 
 type AppError struct {
@@ -165,7 +156,6 @@ var apiErrorMapping = map[string]*AppError{
 	"get_media_details_failed": NewAppError(ErrCodeGetMediaDetailsFailed, "Error al obtener detalles del media", nil),
 	"search_video_id_failed":   NewAppError(ErrCodeSearchVideoIDFailed, "Error al buscar el ID del video", nil),
 	"get_video_details_failed": NewAppError(ErrCodeGetVideoDetailsFailed, "Error al obtener detalles del video", nil),
-	"db_connection_failed":     NewAppError(ErrCodeDBConnectionFailed, "Error de conexión a la base de datos", nil),
 	"save_media_failed":        NewAppError(ErrCodeSaveMediaFailed, "Error al guardar el media", nil),
 	"delete_media_failed":      NewAppError(ErrCodeDeleteMediaFailed, "Error al eliminar el media", nil),
 	"get_media_failed":         NewAppError(ErrCodeGetMediaFailed, "Error al obtener el media", nil),
@@ -183,6 +173,11 @@ var apiErrorMapping = map[string]*AppError{
 
 	"ytdlp_command_failed": NewAppError(ErrCodeYTDLPCommandFailed, "Error al ejecutar el comando yt-dlp", nil),
 	"ytdlp_invalid_output": NewAppError(ErrCodeYTDLPInvalidOutput, "Salida inválida de yt-dlp", nil),
+
+	"guild_player_not_found":      NewAppError(ErrCodeGuildPlayerNotFound, "Reproductor no encontrado para el guild especificado", nil),
+	"invalid_guild_id":            NewAppError(ErrCodeInvalidGuildID, "El ID del guild proporcionado no es válido", nil),
+	"guild_player_create_failed":  NewAppError(ErrCodeGuildPlayerCreateFailed, "Error al crear el reproductor para el guild", nil),
+	"guild_player_already_exists": NewAppError(ErrCodeGuildPlayerAlreadyExists, "El reproductor para este guild ya existe", nil),
 }
 
 // GetAPIError devuelve un AppError basado en el código de error de la API externa.


### PR DESCRIPTION
- **Moves Discord messenger to a subpackage:** Moves the `DiscordMessengerAdapter` from `internal/infrastructure/discord` to `internal/infrastructure/discord/messenger`. This improves code organization.
- **Enhances GuildManager error handling:** Implements more specific error codes and messages for `GuildManager` operations, improving debugging and error handling.
- **Updates GuildManager GetGuildPlayer Method:** Modifies the `GetGuildPlayer` method to create a `GuildPlayer` if it doesn't exist.