### PR TITLE
refactor: Refactor infra config for public ALB, IAM & subnet assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 /microservices/audio_processor/song-downloader-infra/terraform.tfvars
 /microservices/butakero_bot/butakero_bot_infra/.terraform/
 /microservices/butakero_bot/butakero_bot_infra/.terraform.lock.hcl
+/microservices/butakero_bot/butakero_bot_infra/terraform.tfvars
 /yt-cookies.txt
 /microservices/audio_processor/yt-cookies.txt

--- a/microservices/audio_processor/song-downloader-infra/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/main.tf
@@ -107,12 +107,12 @@ module "alb" {
   environment  = var.environment
 
   vpc_id             = module.networking.vpc_id
-  subnet_ids         = module.networking.public_subnet_ids
   tags               = var.alb_tags
   security_group_alb = module.security_groups.security_group_alb_id
-  private_subnet_ids = [module.networking.private_subnet_ids[0], module.networking.private_subnet_ids[1]]
+  #private_subnet_ids = [module.networking.private_subnet_ids[0], module.networking.private_subnet_ids[1]]
 
   logs_bucket = module.storage.bucket_name
+  public_subnet_ids = module.networking.public_subnet_ids
 }
 
 module "ecs" {

--- a/microservices/audio_processor/song-downloader-infra/modules/alb/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/alb/main.tf
@@ -1,9 +1,9 @@
 resource "aws_lb" "main" {
   name = "${var.project_name}-alb-${var.environment}"
-  internal = true
+  internal = false
   load_balancer_type = "application"
   security_groups = [var.security_group_alb]
-  subnets = var.private_subnet_ids
+  subnets = var.public_subnet_ids
 
   enable_deletion_protection = false
   preserve_host_header = true

--- a/microservices/audio_processor/song-downloader-infra/modules/alb/variables.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/alb/variables.tf
@@ -13,15 +13,15 @@ variable "vpc_id" {
   type = string
 }
 
-variable "subnet_ids" {
-  description = "IDs de las subnets (para compatibilidad)"
+variable "public_subnet_ids" {
+  description = "IDs de las subnets publicas para el ALB publico"
   type = list(string)
 }
 
-variable "private_subnet_ids" {
-  description = "IDs de las subnets privadas para el ALB interno"
-  type = list(string)
-}
+# variable "private_subnet_ids" {
+#   description = "IDs de las subnets privadas para el ALB interno"
+#   type = list(string)
+# }
 
 variable "container_port" {
   description = "Puerto del contenedor"

--- a/microservices/audio_processor/song-downloader-infra/modules/iam/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/iam/main.tf
@@ -73,7 +73,10 @@ resource "aws_iam_role_policy" "ecs_task_role_policy" {
           "dynamodb:DescribeTable"
 
         ]
-        Resource = var.dynamodb_table_arns
+        Resource = flatten([
+          var.dynamodb_table_arns,
+          [for table in var.dynamodb_table_arns : "${table}/index/GSI1"]
+        ])
       },
       {
         Effect = "Allow"

--- a/microservices/audio_processor/song-downloader-infra/modules/networking/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/networking/main.tf
@@ -44,28 +44,28 @@ resource "aws_internet_gateway" "main" {
   }
 }
 
-resource "aws_eip" "nat" {
-  count = 1
-  domain = "vpc"
+# resource "aws_eip" "nat" {
+#   count = 1
+#   domain = "vpc"
+#
+#   tags = {
+#     Name = "${var.project_name}-eip-nat-${var.environment}"
+#     Environment = var.environment
+#     Project = var.project_name
+#   }
+# }
 
-  tags = {
-    Name = "${var.project_name}-eip-nat-${var.environment}"
-    Environment = var.environment
-    Project = var.project_name
-  }
-}
-
-resource "aws_nat_gateway" "main" {
-  count = 1
-  allocation_id = aws_eip.nat[0].id
-  subnet_id     = aws_subnet.public[0].id
-
-  tags = {
-    Name = "${var.project_name}-nat-${var.environment}"
-    Environment = var.environment
-    Project = var.project_name
-  }
-}
+# resource "aws_nat_gateway" "main" {
+#   count = 1
+#   allocation_id = aws_eip.nat[0].id
+#   subnet_id     = aws_subnet.public[0].id
+#
+#   tags = {
+#     Name = "${var.project_name}-nat-${var.environment}"
+#     Environment = var.environment
+#     Project = var.project_name
+#   }
+# }
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
@@ -81,19 +81,19 @@ resource "aws_route_table" "public" {
   }
 }
 
-resource "aws_route_table" "private" {
-  vpc_id = aws_vpc.main.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.main[0].id
-  }
-
-  tags = {
-    Name        = "${var.project_name}-rt-private-${var.environment}"
-    Environment = var.environment
-  }
-}
+# resource "aws_route_table" "private" {
+#   vpc_id = aws_vpc.main.id
+#
+#   route {
+#     cidr_block = "0.0.0.0/0"
+#     nat_gateway_id = aws_nat_gateway.main[0].id
+#   }
+#
+#   tags = {
+#     Name        = "${var.project_name}-rt-private-${var.environment}"
+#     Environment = var.environment
+#   }
+# }
 
 resource "aws_route_table_association" "public" {
   count = 2
@@ -101,11 +101,11 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public.id
 }
 
-resource "aws_route_table_association" "private" {
-  count = 2
-  subnet_id = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private.id
-}
+# resource "aws_route_table_association" "private" {
+#   count = 2
+#   subnet_id = aws_subnet.private[count.index].id
+#   route_table_id = aws_route_table.private.id
+# }
 
 data "aws_availability_zones" "available" {
   state = "available"

--- a/microservices/audio_processor/song-downloader-infra/modules/networking/outputs.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/networking/outputs.tf
@@ -8,7 +8,7 @@ output "public_subnet_ids" {
   value = aws_subnet.public[*].id
 }
 
-output "private_subnet_ids" {
-  description = "IDs de las subnets privadas"
-  value = aws_subnet.private[*].id
-}
+# output "private_subnet_ids" {
+#   description = "IDs de las subnets privadas"
+#   value = aws_subnet.private[*].id
+# }

--- a/microservices/audio_processor/song-downloader-infra/modules/security_groups/main.tf
+++ b/microservices/audio_processor/song-downloader-infra/modules/security_groups/main.tf
@@ -36,8 +36,8 @@ resource "aws_security_group" "alb" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
-    description = "Permitir el trafico HTTP desde dentro de la VPC"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Permitir el trafico HTTP desde internet"
   }
 
   egress {
@@ -54,4 +54,9 @@ resource "aws_security_group" "alb" {
       Name = "${var.project_name}-${var.environment}-alb-sg"
     }
   )
+}
+
+
+data "http" "myip" {
+  url = "https://ipv4.icanhazip.com"
 }

--- a/microservices/audio_processor/song-downloader-infra/outputs.tf
+++ b/microservices/audio_processor/song-downloader-infra/outputs.tf
@@ -48,7 +48,7 @@ output "public_subnet_ids" {
   description = "Lista de IDs de subnets públicas"
 }
 
-output "private_subnet_ids" {
-  value = module.networking.private_subnet_ids
-    description = "Lista de IDs de subnets privadas"
-}
+# output "private_subnet_ids" {
+#   value = module.networking.private_subnet_ids
+#     description = "Lista de IDs de subnets privadas"
+# }

--- a/microservices/butakero_bot/butakero_bot_infra/main.tf
+++ b/microservices/butakero_bot/butakero_bot_infra/main.tf
@@ -17,7 +17,7 @@ module "ecs" {
   cpu                       = "256"
   memory                    = "512"
   desired_count             = 1
-  subnets                   = module.networking.private_subnet_ids
+  public_subnet_ids         = module.networking.public_subnet_ids
   security_group_id         = aws_security_group.music_bot_sg.id
   ecs_task_execution_role_arn = module.iam.ecs_task_execution_role_arn
   aws_region                = var.aws_region

--- a/microservices/butakero_bot/butakero_bot_infra/modules/ecs/main.tf
+++ b/microservices/butakero_bot/butakero_bot_infra/modules/ecs/main.tf
@@ -52,7 +52,7 @@ resource "aws_ecs_service" "music_bot_service" {
   force_new_deployment = true
 
   network_configuration {
-    subnets          = var.subnets
+    subnets          = var.public_subnet_ids
     security_groups  = [var.security_group_id]
     assign_public_ip = true
   }

--- a/microservices/butakero_bot/butakero_bot_infra/modules/ecs/variables.tf
+++ b/microservices/butakero_bot/butakero_bot_infra/modules/ecs/variables.tf
@@ -26,7 +26,7 @@ variable "desired_count" {
   default     = 1
 }
 
-variable "subnets" {
+variable "public_subnet_ids" {
   description = "Lista de subnets donde se desplegará el bot de música"
   type        = list(string)
 }

--- a/microservices/butakero_bot/butakero_bot_infra/modules/iam/main.tf
+++ b/microservices/butakero_bot/butakero_bot_infra/modules/iam/main.tf
@@ -43,7 +43,7 @@ resource "aws_iam_role" "ecs_task_role" {
 
 resource "aws_iam_policy" "ecs_task_policy" {
   name        = "ecsTaskPolicy"
-  description = "Permite acceso a DynamoDB, S3, SQS y Secrets Manager"
+  description = "Permite acceso a S3, SQS y Secrets Manager"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -51,7 +51,6 @@ resource "aws_iam_policy" "ecs_task_policy" {
       {
         Effect = "Allow"
         Action = [
-          "dynamodb:*",
           "s3:*",
           "sqs:*",
           "secretsmanager:GetSecretValue",

--- a/microservices/butakero_bot/butakero_bot_infra/modules/networking/outputs.tf
+++ b/microservices/butakero_bot/butakero_bot_infra/modules/networking/outputs.tf
@@ -7,8 +7,3 @@ output "public_subnet_ids" {
   description = "Lista de subnets privadas"
   value       = data.terraform_remote_state.networking.outputs.public_subnet_ids
 }
-
-output "private_subnet_ids" {
-  value = data.terraform_remote_state.networking.outputs.private_subnet_ids
-    description = "Lista de subnets privadas"
-}

--- a/microservices/butakero_bot/butakero_bot_infra/terraform.example.tfvars
+++ b/microservices/butakero_bot/butakero_bot_infra/terraform.example.tfvars
@@ -1,0 +1,3 @@
+aws_region = "us-east-1"
+discord_token = "" // aca pone tu token de discord
+command_prefix = "butakero"


### PR DESCRIPTION
- **ALB made Public:** The ALB for the audio processor is now public, exposed through public subnets, instead of internal via private subnets. This allows direct access to the audio processor service from the internet.
  - Purpose: To enable external clients (e.g., web applications) to directly access the audio processing service without needing to be within the VPC.
  - Technical Impact:  Changes the ALB's `internal` attribute to `false` and assigns `public_subnet_ids` to it. The security group also now allows inbound traffic from 0.0.0.0/0.

- **IAM Policy Update for Butakero Bot:** Removed DynamoDB permissions from the IAM policy for the Butakero Bot.
  - Purpose: To restrict the Butakero bot's access to only the necessary AWS resources, following the principle of least privilege.  DynamoDB access was determined to be unnecessary.
  - Technical Impact: Reduces the scope of actions the Butakero bot can perform, enhancing security.

- **Subnet Assignment Changes for Butakero Bot:** Updated the Butakero Bot to run on public subnets.
  - Purpose: To simplify the infrastructure and potentially reduce costs by removing the need for a NAT gateway.
  - Technical Impact:  The ECS service configuration now uses `public_subnet_ids` and assigns a public IP. This will cause the container to receive a public IP address.