### PR TITLE
fix: Enhance trace ID, context, and audio transmission handling

### DIFF
--- a/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
@@ -55,7 +55,7 @@ func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.Interactio
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "PlaySong"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),
@@ -88,7 +88,7 @@ func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.Interactio
 		return
 	}
 
-	go func() {
+	go func(ctx context.Context) {
 		song, err := h.songService.GetOrDownloadSong(ctx, userID, input, "youtube")
 		if err != nil {
 			logger.Error("Error al obtener canción", zap.Error(err))
@@ -134,7 +134,7 @@ func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.Interactio
 		}); err != nil {
 			logger.Error("Error al actualizar mensaje de confirmación", zap.Error(err))
 		}
-	}()
+	}(ctx)
 }
 
 func (h *CommandHandler) StopPlaying(s *discordgo.Session, ic *discordgo.InteractionCreate, _ *discordgo.ApplicationCommandInteractionDataOption) {
@@ -143,7 +143,7 @@ func (h *CommandHandler) StopPlaying(s *discordgo.Session, ic *discordgo.Interac
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "StopPlaying"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),
@@ -188,7 +188,7 @@ func (h *CommandHandler) isUserInVoiceChannel(s *discordgo.Session, ic *discordg
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "isUserInVoiceChannel"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("user_id", ic.Member.User.ID),
 		zap.String("method", "isUserInVoiceChannel"),
@@ -239,7 +239,7 @@ func (h *CommandHandler) SkipSong(s *discordgo.Session, ic *discordgo.Interactio
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "SkipSong"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),
@@ -271,7 +271,7 @@ func (h *CommandHandler) ListPlaylist(s *discordgo.Session, ic *discordgo.Intera
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "ListPlaylist"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),
@@ -329,7 +329,7 @@ func (h *CommandHandler) RemoveSong(s *discordgo.Session, ic *discordgo.Interact
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "RemoveSong"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),
@@ -378,7 +378,7 @@ func (h *CommandHandler) GetPlayingSong(s *discordgo.Session, ic *discordgo.Inte
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "GetPlayingSong"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),
@@ -437,7 +437,7 @@ func (h *CommandHandler) PauseSong(s *discordgo.Session, ic *discordgo.Interacti
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "PauseSong"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),
@@ -482,7 +482,7 @@ func (h *CommandHandler) ResumeSong(s *discordgo.Session, ic *discordgo.Interact
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "ResumeSong"),
-		zap.String("trace_id", ctx.Value("trace_id").(string)),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("guild_id", ic.GuildID),
 		zap.String("channel_id", ic.ChannelID),
 		zap.String("user_id", ic.Member.User.ID),

--- a/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
@@ -110,6 +110,7 @@ func (h *EventHandler) GuildDelete(_ *discordgo.Session, event *discordgo.GuildD
 
 // RegisterEventHandlers registra los manejadores de eventos en la sesión de Discord.
 func (h *EventHandler) RegisterEventHandlers(ctx context.Context, s *discordgo.Session) {
+	ctx = trace.WithTraceID(ctx)
 	logger := h.logger.With(
 		zap.String("component", "EventHandler"),
 		zap.String("method", "RegisterEventHandlers"),
@@ -122,8 +123,7 @@ func (h *EventHandler) RegisterEventHandlers(ctx context.Context, s *discordgo.S
 	})
 	s.AddHandler(h.GuildDelete)
 	s.AddHandler(func(session *discordgo.Session, event *discordgo.VoiceStateUpdate) {
-		voiceCtx := context.WithValue(ctx, TraceIDKey, trace.GenerateTraceID())
-		h.VoiceStateUpdate(voiceCtx, session, event)
+		h.VoiceStateUpdate(ctx, session, event)
 	})
 
 	logger.Info("Manejadores de eventos registrados")

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -421,7 +421,7 @@ func (gp *GuildPlayer) handlePlayEvent(ctx context.Context, event PlayEvent) err
 		return fmt.Errorf("error al unirse al canal de voz: %w", err)
 	}
 
-	logger.Info("Comenzando reproducción de playlist")
+	logger.Debug("Comenzando reproducción de playlist")
 
 	for {
 		song, err := gp.playlistHandler.GetNextSong(ctx)

--- a/microservices/butakero_bot/internal/infrastructure/discord/voice/voice_session.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/voice/voice_session.go
@@ -3,6 +3,7 @@ package voice
 import (
 	"context"
 	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"io"
 	"sync/atomic"
 	"time"
@@ -32,45 +33,70 @@ func NewDiscordVoiceSession(s *discordgo.Session, guildID string, logger logging
 		session:     s,
 		guildID:     guildID,
 		logger:      logger,
-		sendTimeout: 1 * time.Second,
+		sendTimeout: 3 * time.Second,
 	}
 }
 
 // JoinVoiceChannel conecta la sesión a un canal de voz específico usando channelID
 func (d *DiscordVoiceSession) JoinVoiceChannel(channelID string) error {
-	d.logger.Debug("Conectando al canal de voz", zap.String("channelID", channelID))
+	logger := d.logger.With(
+		zap.String("component", "DiscordVoiceSession"),
+		zap.String("method", "JoinVoiceChannel"),
+		zap.String("channelID", channelID),
+		zap.String("guild_id", d.guildID),
+	)
+	logger.Debug("Conectando al canal de voz", zap.String("channelID", channelID))
 	vc, err := d.session.ChannelVoiceJoin(d.guildID, channelID, false, true)
 	if err != nil {
-		d.logger.Error("Falló la conexión al canal de voz", zap.Error(err))
+		logger.Error("Falló la conexión al canal de voz", zap.Error(err))
 		return err
 	}
 	d.vc = vc
+	logger.Debug("Conexión de voz establecida exitosamente")
 	return nil
 }
 
 // SendAudio manda frames de audio a la conexión de voz de Discord
 func (d *DiscordVoiceSession) SendAudio(ctx context.Context, reader io.ReadCloser) error {
+	logger := d.logger.With(
+		zap.String("component", "DiscordVoiceSession"),
+		zap.String("method", "SendAudio"),
+		zap.String("guild_id", d.guildID),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
+	)
+
 	if d.vc == nil {
+		logger.Error("Intento de enviar audio sin conexión de voz")
 		return ErrNoVoiceConnection
 	}
 
 	defer func() {
-		_ = reader.Close()
+		if err := reader.Close(); err != nil {
+			logger.Warn("Error al cerrar reader de audio",
+				zap.Error(err))
+		}
 		if err := d.vc.Speaking(false); err != nil {
-			d.logger.Error("Error al dejar de hablar", zap.Error(err))
+			logger.Error("Error al dejar de hablar",
+				zap.Error(err))
 		}
 	}()
 
+	logger.Debug("Iniciando transmisión de audio")
+
 	if err := d.vc.Speaking(true); err != nil {
-		d.logger.Error("Error al empezar a hablar", zap.Error(err))
+		logger.Error("Error al empezar a hablar", zap.Error(err))
 		return err
 	}
 
 	decoderAudio := decoder.NewBufferedOpusDecoder(reader)
+	frameCount := 0
 
 	for {
 		select {
 		case <-ctx.Done():
+			logger.Debug("Transmisión cancelada por contexto",
+				zap.String("reason", ctx.Err().Error()),
+				zap.Int("frames_sent", frameCount))
 			return ctx.Err()
 		default:
 		}
@@ -83,17 +109,28 @@ func (d *DiscordVoiceSession) SendAudio(ctx context.Context, reader io.ReadClose
 		frame, err := decoderAudio.OpusFrame()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				logger.Debug("Transmisión de audio completada",
+					zap.Int("total_frames", frameCount))
 				return nil
 			}
-			d.logger.Error("Error decodificando el frame", zap.Error(err))
+			logger.Error("Error decodificando frame de audio",
+				zap.Error(err),
+				zap.Int("frames_sent", frameCount))
 			return err
 		}
 
 		select {
 		case d.vc.OpusSend <- frame:
+			frameCount++
 		case <-ctx.Done():
+			logger.Debug("Transmisión interrumpida durante envío",
+				zap.String("reason", ctx.Err().Error()),
+				zap.Int("frames_sent", frameCount))
 			return ctx.Err()
 		case <-time.After(d.sendTimeout):
+			logger.Error("Timeout al enviar frame de audio",
+				zap.Duration("timeout", d.sendTimeout),
+				zap.Int("frames_sent", frameCount))
 			return ErrSendTimeout
 		}
 	}
@@ -115,16 +152,37 @@ func (d *DiscordVoiceSession) Resume() {
 
 // LeaveVoiceChannel desconecta del canal de voz
 func (d *DiscordVoiceSession) LeaveVoiceChannel() error {
-	if d.vc != nil {
-		d.logger.Debug("Saliendo del canal de voz")
-		err := d.vc.Disconnect()
-		d.vc = nil
+	logger := d.logger.With(
+		zap.String("component", "DiscordVoiceSession"),
+		zap.String("method", "LeaveVoiceChannel"),
+		zap.String("guild_id", d.guildID),
+	)
+	if d.vc == nil {
+		logger.Debug("Intento de desconexión sin conexión activa")
+		return nil
+	}
+
+	logger.Debug("Desconectando del canal de voz")
+	err := d.vc.Disconnect()
+	d.vc = nil
+
+	if err != nil {
+		logger.Error("Error al desconectar del canal de voz",
+			zap.Error(err))
 		return err
 	}
+
+	logger.Debug("Desconexión exitosa")
 	return nil
 }
 
 // SetSendTimeout configura el timeout para enviar frames de audio
 func (d *DiscordVoiceSession) SetSendTimeout(timeout time.Duration) {
+	d.logger.Info("Actualizando timeout de envío",
+		zap.String("component", "DiscordVoiceSession"),
+		zap.String("guild_id", d.guildID),
+		zap.String("method", "SetSendTimeout"),
+		zap.Duration("old_timeout", d.sendTimeout),
+		zap.Duration("new_timeout", timeout))
 	d.sendTimeout = timeout
 }

--- a/microservices/butakero_bot/internal/infrastructure/discord/voice/voice_session.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/voice/voice_session.go
@@ -71,10 +71,6 @@ func (d *DiscordVoiceSession) SendAudio(ctx context.Context, reader io.ReadClose
 	}
 
 	defer func() {
-		if err := reader.Close(); err != nil {
-			logger.Warn("Error al cerrar reader de audio",
-				zap.Error(err))
-		}
 		if err := d.vc.Speaking(false); err != nil {
 			logger.Error("Error al dejar de hablar",
 				zap.Error(err))

--- a/microservices/butakero_bot/internal/shared/trace/trace.go
+++ b/microservices/butakero_bot/internal/shared/trace/trace.go
@@ -20,7 +20,3 @@ func WithTraceID(ctx context.Context) context.Context {
 	traceID := uuid.New().String()
 	return context.WithValue(ctx, traceIDKey{}, traceID)
 }
-
-func GenerateTraceID() string {
-	return uuid.New().String()
-}


### PR DESCRIPTION
- **Standardize Trace ID Retrieval:** Replaced direct context value access for trace IDs with the `trace.GetTraceID(ctx)` function across the `CommandHandler` and `DiscordVoiceSession`. This ensures consistent and reliable retrieval of trace IDs.
- **Pass Context to Goroutine:** Modified the `PlaySong` function to pass the context to the goroutine. This allows the goroutine to be aware of deadlines, cancellations, and trace information.
- **Increased Audio Send Timeout and Improved Error Handling:** Increased the `sendTimeout` in `DiscordVoiceSession` from 1 to 3 seconds to improve audio transmission reliability, and added more robust error handling with logging during audio sending, including handling of EOF, context cancellation, and timeouts.