### PR TITLE
refactor: Decouple event registration from context, refine logging

### DIFF
--- a/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
@@ -119,7 +119,7 @@ func StartBot() error {
 		command.NewResumeCommand(handler, logger),
 	}
 
-	eventsHandler.RegisterEventHandlers(ctx, discordClient)
+	eventsHandler.RegisterEventHandlers(discordClient)
 	discordClient.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		if i.Type == discordgo.InteractionApplicationCommand {
 			if h, ok := commandRegistry.GetCommandHandlers()[i.ApplicationCommandData().Name]; ok {

--- a/microservices/butakero_bot/cmd/bot_local/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_local/bot/bot.go
@@ -124,7 +124,7 @@ func StartBot() error {
 		command.NewResumeCommand(handler, logger),
 	}
 
-	eventsHandler.RegisterEventHandlers(ctx, discordClient)
+	eventsHandler.RegisterEventHandlers(discordClient)
 	discordClient.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		if i.Type == discordgo.InteractionApplicationCommand {
 			if h, ok := commandRegistry.GetCommandHandlers()[i.ApplicationCommandData().Name]; ok {

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -288,13 +288,13 @@ func (gp *GuildPlayer) Run(ctx context.Context) error {
 	gp.running = true
 	gp.mu.Unlock()
 
-	logger.Info("Iniciando GuildPlayer")
+	logger.Debug("Iniciando GuildPlayer")
 
 	defer func() {
 		gp.mu.Lock()
 		gp.running = false
 		gp.mu.Unlock()
-		logger.Info("GuildPlayer detenido")
+		logger.Debug("GuildPlayer detenido")
 	}()
 
 	currentSong, err := gp.stateStorage.GetCurrentTrack(ctx)
@@ -315,7 +315,10 @@ func (gp *GuildPlayer) Run(ctx context.Context) error {
 		}
 	}
 
+	fmt.Println("seso")
+
 	for {
+		fmt.Println("seso1")
 		select {
 		case <-ctx.Done():
 			logger.Info("Contexto cancelado - cerrando GuildPlayer")


### PR DESCRIPTION
- **Decoupled event registration from context:** The `RegisterEventHandlers` function in `events.go` no longer requires a context object.
  - **Purpose:** Simplifies event registration and avoids unnecessary context dependencies.
  - **Technical impact:** Eliminates the need to pass a context during event handler registration.

- **Refined logging:** Improved logging within `events.go` and `player.go` for better debugging and monitoring.
  - **Purpose:** Provides more insightful log messages for event handling and player lifecycle.
  - **Technical impact:** Enhanced observability without functional changes.

- **Trace ID context creation inside event handler:** The trace ID context is created inside the event handlers.
  - **Purpose:** Ensures trace IDs are properly initiated and available for each event.
  - **Technical impact:** Ensures that each event is properly traced.