### PR TITLE
feat: Add trace ID to logs & fix GuildPlayer lifecycle

### DIFF
--- a/microservices/butakero_bot/internal/application/service/song_service.go
+++ b/microservices/butakero_bot/internal/application/service/song_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model/queue"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"regexp"
@@ -46,6 +47,7 @@ func (s *songService) GetOrDownloadSong(ctx context.Context, userID, songInput, 
 	input, isURL := s.extractURLOrTitle(songInput)
 	s.logger.Info("Procesando solicitud de canción",
 		zap.String("requestID", requestID),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("userID", userID),
 		zap.String("input", input),
 		zap.Bool("isURL", isURL))

--- a/microservices/butakero_bot/internal/infrastructure/adapters/api/media_api_client.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/api/media_api_client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/errors_app"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"go.uber.org/zap"
 	"io"
 	"net/http"
@@ -62,6 +63,7 @@ func (c *MediaAPIClient) GetMediaByID(ctx context.Context, id string) (*model.Me
 	logger := c.logger.With(
 		zap.String("component", "MediaAPIClient"),
 		zap.String("method", "GetMediaByID"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("id", id),
 	)
 
@@ -132,6 +134,7 @@ func (c *MediaAPIClient) SearchMediaByTitle(ctx context.Context, title string) (
 	logger := c.logger.With(
 		zap.String("component", "MediaAPIClient"),
 		zap.String("method", "SearchMediaByTitle"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("title", title),
 	)
 

--- a/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/events/events.go
@@ -68,21 +68,12 @@ func (h *EventHandler) GuildCreate(ctx context.Context, _ *discordgo.Session, ev
 		return
 	}
 
-	guildPlayer, err := h.guildManager.GetGuildPlayer(event.ID)
+	_, err := h.guildManager.GetGuildPlayer(event.ID)
 	if err != nil {
 		logger.Error("Error al obtener GuildPlayer",
 			zap.Error(err))
 		return
 	}
-
-	go func() {
-		if err := guildPlayer.Run(ctx); err != nil {
-			logger.Error("Error al iniciar GuildPlayer",
-				zap.Error(err))
-		} else {
-			logger.Info("GuildPlayer iniciado exitosamente")
-		}
-	}()
 }
 
 // GuildDelete se llama cuando el bot es removido de un servidor.

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
@@ -242,6 +242,10 @@ func (pc *PlaybackController) playSong(ctx context.Context, song *entity.PlayedS
 				}
 			}
 
+			if err := pc.stateStorage.SetCurrentTrack(ctx, nil); err != nil {
+				logger.Error("Error al limpiar estado de canción actual", zap.Error(err))
+			}
+
 			pc.mu.Lock()
 			pc.stateManager.SetState(StateIdle)
 			pc.currentSong = nil

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -76,7 +76,20 @@ func (gp *GuildPlayer) AddSong(ctx context.Context, textChannelID, voiceChannelI
 
 	logger.Info("Canción agregada a la lista",
 		zap.Any("text_channel", textChannelID),
-		zap.Any("voice_channel", voiceChannelID))
+		zap.Any("voice_channel", voiceChannelID),
+	)
+
+	gp.mu.Lock()
+	shouldStart := !gp.running
+	gp.mu.Unlock()
+
+	if shouldStart {
+		go func() {
+			if err := gp.Run(ctx); err != nil {
+				logger.Error("Error al iniciar reproducción", zap.Error(err))
+			}
+		}()
+	}
 
 	return nil
 }
@@ -315,10 +328,7 @@ func (gp *GuildPlayer) Run(ctx context.Context) error {
 		}
 	}
 
-	fmt.Println("seso")
-
 	for {
-		fmt.Println("seso1")
 		select {
 		case <-ctx.Done():
 			logger.Info("Contexto cancelado - cerrando GuildPlayer")

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_consumer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_consumer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model/queue"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"sync"
 
 	"github.com/IBM/sarama"
@@ -83,7 +84,8 @@ func NewKafkaConsumer(config ConfigKafka, logger logging.Logger) (ports.SongDown
 func (k *ConsumerKafka) SubscribeToDownloadEvents(ctx context.Context) error {
 	logger := k.logger.With(
 		zap.String("component", "ConsumerKafka"),
-		zap.String("method", "SubscribeToDownloadEvents"))
+		zap.String("method", "SubscribeToDownloadEvents"),
+		zap.String("trace_id", trace.GetTraceID(ctx)))
 	logger.Info("Iniciando consumo de mensajes")
 
 	exists, err := k.TopicExists(k.topic)
@@ -136,6 +138,7 @@ func (k *ConsumerKafka) consumePartition(ctx context.Context, pc sarama.Partitio
 	logger := k.logger.With(
 		zap.String("component", "ConsumerKafka"),
 		zap.String("method", "consumePartition"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.Int32("partition", partition),
 	)
 

--- a/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/kafka/kafka_producer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"go.uber.org/zap"
 	"time"
 )
@@ -69,6 +70,7 @@ func (p *ProducerKafka) PublishDownloadRequest(ctx context.Context, message *que
 	log := p.logger.With(
 		zap.String("component", "ProducerKafka"),
 		zap.String("method", "PublishDownloadRequest"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("topic", p.cfg.QueueConfig.KafkaConfig.Topics.BotDownloadRequest),
 		zap.String("request_id", message.RequestID),
 	)

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model/queue"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
@@ -48,7 +49,9 @@ func NewSQSConsumer(client ClientSQS, config *config.Config, logger logging.Logg
 func (s *ConsumerSQS) SubscribeToDownloadEvents(ctx context.Context) error {
 	logger := s.logger.With(
 		zap.String("component", "ConsumerSQS"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("method", "SubscribeToDownloadEvents"))
+
 	logger.Info("Iniciando consumo de mensajes SQS")
 
 	s.wg.Add(1)
@@ -72,6 +75,7 @@ func (s *ConsumerSQS) SubscribeToDownloadEvents(ctx context.Context) error {
 func (s *ConsumerSQS) receiveAndProcessMessages(ctx context.Context) {
 	logger := s.logger.With(
 		zap.String("component", "ConsumerSQS"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("method", "receiveAndProcessMessages"))
 
 	input := &sqs.ReceiveMessageInput{
@@ -99,6 +103,7 @@ func (s *ConsumerSQS) receiveAndProcessMessages(ctx context.Context) {
 func (s *ConsumerSQS) handleMessage(ctx context.Context, msg types.Message) {
 	logger := s.logger.With(
 		zap.String("component", "ConsumerSQS"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("method", "handleMessage"),
 	)
 
@@ -134,6 +139,7 @@ func (s *ConsumerSQS) deleteMessage(ctx context.Context, msg types.Message) {
 	logger := s.logger.With(
 		zap.String("component", "ConsumerSQS"),
 		zap.String("method", "deleteMessage"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("messageID", *msg.MessageId),
 	)
 

--- a/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer.go
+++ b/microservices/butakero_bot/internal/infrastructure/messaging/sqs/sqs_producer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model/queue"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsCfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
@@ -49,6 +50,7 @@ func NewProducerSQS(cfgApplication *config.Config, log logging.Logger) (ports.So
 func (p *ProducerSQS) PublishDownloadRequest(ctx context.Context, message *queue.DownloadRequestMessage) error {
 	log := p.logger.With(
 		zap.String("component", "ProducerSQS"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("method", "PublishDownloadRequest"),
 		zap.String("queue_url", p.cfg.QueueConfig.SQSConfig.Queues.BotDownloadRequestsQueueURL),
 	)

--- a/microservices/butakero_bot/internal/infrastructure/storage/local/local_storage.go
+++ b/microservices/butakero_bot/internal/infrastructure/storage/local/local_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"go.uber.org/zap"
 	"io"
 	"os"
@@ -29,6 +30,8 @@ func (s *LocalStorage) GetAudio(ctx context.Context, songPath string) (io.ReadCl
 	}
 
 	logger := s.logger.With(
+		zap.String("component", "LocalStorage"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("method", "GetAudio"),
 		zap.String("songPath", songPath),
 	)

--- a/microservices/butakero_bot/internal/infrastructure/storage/s3_storage/s3_storage.go
+++ b/microservices/butakero_bot/internal/infrastructure/storage/s3_storage/s3_storage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsCfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -49,6 +50,8 @@ func (s *S3Storage) GetAudio(ctx context.Context, songPath string) (io.ReadClose
 	}
 
 	logger := s.logger.With(
+		zap.String("component", "S3Storage"),
+		zap.String("trace_id", trace.GetTraceID(ctx)),
 		zap.String("method", "GetAudio"),
 		zap.String("songPath", songPath),
 	)


### PR DESCRIPTION
- **Add trace ID to logs:** Adds the trace ID to all log messages for easier request tracing across services. This applies to MediaAPIClient, Kafka consumer/producer, SQS consumer/producer, Local/S3 Storage and song service.
    - Purpose: Improves observability and debugging by allowing correlation of log messages across different services involved in a request.
    - Technical Impact: Requires the context to carry the trace ID for retrieval.

- **Improve GuildPlayer lifecycle:** Restructures the GuildPlayer's `Run` method and song completion logic. Prevents multiple `Run` calls by adding a running flag and ensures the next song plays automatically after completion and it clears the current track state.
    - Purpose: Fixes issues with the bot's music playback, specifically related to song completion and the player not advancing to the next song, and ensures the player starts when a song is added to the queue.
    - Technical Impact: Changes how the GuildPlayer is started and how the playback controller manages the state.

- **Remove GuildPlayer.Run() call on GuildCreate event:** Removes the explicit call to guildPlayer.Run() when a GuildCreate event occurs.
    - Purpose: Prevents an issue where `GuildPlayer.Run()` could be called multiple times and now ensures the player starts when a song is added to the queue.
    - Technical Impact: Code simplification, relies on the new GuildPlayer lifecycle improvements to ensure the player is properly initialized.