### PR TITLE
feat: Implement GuildPlayer resource management and enhance state access

### DIFF
--- a/microservices/butakero_bot/internal/domain/ports/discord.go
+++ b/microservices/butakero_bot/internal/domain/ports/discord.go
@@ -17,6 +17,7 @@ type (
 		GetPlayedSong(ctx context.Context) (*entity.PlayedSong, error)
 		StateStorage() PlayerStateStorage
 		JoinVoiceChannel(ctx context.Context, channelID string) error
+		Close() error
 	}
 
 	GuildManager interface {

--- a/microservices/butakero_bot/internal/infrastructure/discord/guild_manager_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/guild_manager_test.go
@@ -131,6 +131,7 @@ func TestGuildManager_RemoveGuildPlayer(t *testing.T) {
 	mockPlayerFactory := new(MockPlayerFactory)
 	mockPlayerFactory.On("CreatePlayer", "guild123").Return(mockGuildPlayer, nil)
 	mockPlayerFactory.On("CreatePlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("Close").Return(nil)
 
 	guildManager := NewGuildManager(mockPlayerFactory, mockLogger)
 

--- a/microservices/butakero_bot/internal/infrastructure/discord/mocks.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/mocks.go
@@ -69,6 +69,12 @@ func (m *MockGuildPlayer) JoinVoiceChannel(ctx context.Context, channelID string
 	return args.Error(0)
 }
 
+func (m *MockGuildPlayer) Close() error {
+	args := m.Called()
+	return args.Error(0)
+
+}
+
 type MockStateStorage struct {
 	mock.Mock
 }

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/controller.go
@@ -25,7 +25,7 @@ type PlaybackController struct {
 	stateManager  *StateManager
 	currentCancel context.CancelFunc
 	isPaused      atomic.Bool
-	mu            sync.Mutex
+	mu            sync.RWMutex
 	currentSong   *entity.PlayedSong
 	playMsgID     string
 }
@@ -150,6 +150,8 @@ func (pc *PlaybackController) Stop(ctx context.Context) {
 }
 
 func (pc *PlaybackController) CurrentState() PlayerState {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
 	return pc.stateManager.GetState()
 }
 

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/events.go
@@ -1,5 +1,7 @@
 package player
 
+import "context"
+
 type EventType string
 
 const (
@@ -14,6 +16,7 @@ type (
 	// PlayerEvent es la interfaz que todos los eventos del reproductor deben implementar
 	PlayerEvent interface {
 		Type() EventType
+		HandleEvent(ctx context.Context, player *GuildPlayer) error
 	}
 )
 
@@ -34,10 +37,31 @@ type (
 
 func (e PlayEvent) Type() EventType { return EventTypePlay }
 
+func (e PlayEvent) HandleEvent(ctx context.Context, player *GuildPlayer) error {
+	return player.handlePlayEvent(ctx, e)
+}
+
 func (e PauseEvent) Type() EventType { return EventTypePause }
+
+func (e PauseEvent) HandleEvent(ctx context.Context, player *GuildPlayer) error {
+	return player.Pause(ctx)
+}
 
 func (e ResumeEvent) Type() EventType { return EventTypeResume }
 
+func (e ResumeEvent) HandleEvent(ctx context.Context, player *GuildPlayer) error {
+	return player.Resume(ctx)
+}
+
 func (e StopEvent) Type() EventType { return EventTypeStop }
 
+func (e StopEvent) HandleEvent(ctx context.Context, player *GuildPlayer) error {
+	return player.Stop(ctx)
+}
+
 func (e SkipEvent) Type() EventType { return EventTypeSkip }
+
+func (e SkipEvent) HandleEvent(ctx context.Context, player *GuildPlayer) error {
+	player.SkipSong(ctx)
+	return nil
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/interfaces"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/voice"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -35,7 +34,6 @@ type GuildPlayer struct {
 	stateStorage    ports.PlayerStateStorage
 	eventCh         chan PlayerEvent
 	logger          logging.Logger
-	mu              sync.Mutex
 	running         atomic.Bool
 }
 

--- a/microservices/butakero_bot/internal/shared/errors_app/errors.go
+++ b/microservices/butakero_bot/internal/shared/errors_app/errors.go
@@ -50,6 +50,7 @@ const (
 	ErrCodeInvalidGuildID           ErrorCode = "invalid_guild_id"
 	ErrCodeGuildPlayerAlreadyExists ErrorCode = "guild_player_already_exists"
 	ErrCodeGuildPlayerCreateFailed  ErrorCode = "guild_player_create_failed"
+	ErrCodeGuildPlayerCloseFailed   ErrorCode = "guild_player_close_failed"
 )
 
 var errorStatusMap = map[ErrorCode]int{
@@ -99,6 +100,7 @@ var errorStatusMap = map[ErrorCode]int{
 	ErrCodeInvalidGuildID:            http.StatusBadRequest,
 	ErrCodeGuildPlayerCreateFailed:   http.StatusInternalServerError,
 	ErrCodeGuildPlayerAlreadyExists:  http.StatusConflict,
+	ErrCodeGuildPlayerCloseFailed:    http.StatusInternalServerError,
 }
 
 type AppError struct {
@@ -178,6 +180,7 @@ var apiErrorMapping = map[string]*AppError{
 	"invalid_guild_id":            NewAppError(ErrCodeInvalidGuildID, "El ID del guild proporcionado no es válido", nil),
 	"guild_player_create_failed":  NewAppError(ErrCodeGuildPlayerCreateFailed, "Error al crear el reproductor para el guild", nil),
 	"guild_player_already_exists": NewAppError(ErrCodeGuildPlayerAlreadyExists, "El reproductor para este guild ya existe", nil),
+	"guild_player_close_failed":   NewAppError(ErrCodeGuildPlayerCloseFailed, "Error al cerrar el reproductor del guild", nil),
 }
 
 // GetAPIError devuelve un AppError basado en el código de error de la API externa.


### PR DESCRIPTION
- **Implement `GuildPlayer.Close()`**: Adds a `Close()` method to `GuildPlayer` for resource cleanup (stopping playback, clearing event channel). This ensures proper shutdown and prevents resource leaks.
- **Enhance `GuildManager.RemoveGuildPlayer()`**:  The `RemoveGuildPlayer` function now calls `Close()` on the `GuildPlayer` before removing it from the map. This ensures resources are released when a player is removed.
- **Enhance Player State Access with `sync.RWMutex`**:  Replaces the `sync.Mutex` in `PlaybackController` with `sync.RWMutex` to allow concurrent read access to player state, improving performance.