### PR TITLE
feat: Add health check endpoint and version info

### DIFF
--- a/microservices/butakero_bot/cmd/bot_local/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_local/bot/bot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/application/service"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/adapters/api"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/adapters/health"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/command"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/events"
@@ -17,6 +18,7 @@ import (
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
 	"github.com/bwmarrin/discordgo"
 	"go.uber.org/zap"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -140,6 +142,33 @@ func StartBot() error {
 	defer func() {
 		if err := discordClient.Close(); err != nil {
 			logger.Error("Error al cerrar la conexión con Discord", zap.Error(err))
+		}
+	}()
+
+	discordChecker := health.NewDiscordChecker(discordClient, logger)
+	serviceBChecker, err := health.NewServiceBChecker(&health.ServiceConfig{
+		BaseURL: cfg.ExternalService.BaseURL,
+		Timeout: 5 * time.Second,
+	}, logger)
+	if err != nil {
+		logger.Error("Error al crear el verificador de salud de Service B", zap.Error(err))
+		return fmt.Errorf("error al crear el verificador de salud de Service B: %v", err)
+	}
+
+	healthHandler := api.NewHealthHandler(discordChecker, serviceBChecker, logger, cfg)
+
+	router := http.NewServeMux()
+	router.HandleFunc("/api/v1/health", healthHandler.Handle)
+
+	server := &http.Server{
+		Addr:    ":8081",
+		Handler: router,
+	}
+
+	go func() {
+		logger.Info("Iniciando servidor HTTP en el puerto 8080")
+		if err := server.ListenAndServe(); err != nil {
+			logger.Error("Error al iniciar el servidor HTTP", zap.Error(err))
 		}
 	}()
 

--- a/microservices/butakero_bot/internal/domain/entity/health.go
+++ b/microservices/butakero_bot/internal/domain/entity/health.go
@@ -1,0 +1,61 @@
+package entity
+
+type HealthStatus string
+
+const (
+	StatusOperational HealthStatus = "operational"
+	StatusDegraded    HealthStatus = "degraded"
+	StatusDown        HealthStatus = "down"
+)
+
+type (
+	HealthResponse struct {
+		Status    HealthStatus   `json:"status"`
+		Discord   DiscordHealth  `json:"discord"`
+		ServiceB  ServiceBHealth `json:"service_b"`
+		Timestamp string         `json:"timestamp"`
+		Message   string         `json:"message,omitempty"`
+		Version   string         `json:"version,omitempty"`
+	}
+
+	DiscordHealth struct {
+		Connected          bool    `json:"connected"`
+		HeartbeatLatencyMS float64 `json:"heartbeat_latency_ms"`
+		Guilds             int     `json:"guilds"`
+		VoiceConnections   int     `json:"voice_connections"`
+		SessionID          string  `json:"session_id,omitempty"`
+		CheckDurationMS    float64 `json:"check_duration_ms,omitempty"`
+		Error              string  `json:"error,omitempty"`
+	}
+
+	ServiceBHealth struct {
+		Connected bool   `json:"connected"`
+		LatencyMS int    `json:"latency_ms"`
+		Status    string `json:"status,omitempty"`
+		Error     string `json:"error,omitempty"`
+	}
+)
+
+func DetermineOverallStatus(discord DiscordHealth, serviceB ServiceBHealth) (HealthStatus, string) {
+	if !discord.Connected && !serviceB.Connected {
+		return StatusDown, "Servicios críticos no disponibles"
+	}
+
+	if !discord.Connected {
+		return StatusDegraded, "Discord no está conectado"
+	}
+
+	if !serviceB.Connected {
+		return StatusDegraded, "Service B no está disponible"
+	}
+
+	if discord.HeartbeatLatencyMS > 1000 {
+		return StatusDegraded, "Discord presenta alta latencia"
+	}
+
+	if serviceB.LatencyMS > 1000 {
+		return StatusDegraded, "Service B presenta alta latencia"
+	}
+
+	return StatusOperational, ""
+}

--- a/microservices/butakero_bot/internal/domain/ports/health_checker.go
+++ b/microservices/butakero_bot/internal/domain/ports/health_checker.go
@@ -1,0 +1,18 @@
+package ports
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+)
+
+type HealthChecker[T any] interface {
+	Check(ctx context.Context) (T, error)
+}
+
+type DiscordHealthChecker interface {
+	HealthChecker[entity.DiscordHealth]
+}
+
+type ServiceBHealthChecker interface {
+	HealthChecker[entity.ServiceBHealth]
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/api/health_handler.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/api/health_handler.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"encoding/json"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
+	"go.uber.org/zap"
+	"net/http"
+	"time"
+)
+
+const (
+	healthCheckContextKey  = "health_check"
+	healthCheckContentType = "application/json"
+)
+
+type HealthHandler struct {
+	discordChecker  ports.DiscordHealthChecker
+	serviceBChecker ports.ServiceBHealthChecker
+	logger          logging.Logger
+	cfg             *config.Config
+}
+
+func NewHealthHandler(
+	discordChecker ports.DiscordHealthChecker,
+	serviceBChecker ports.ServiceBHealthChecker,
+	logger logging.Logger,
+	cfg *config.Config,
+) *HealthHandler {
+	return &HealthHandler{
+		discordChecker:  discordChecker,
+		serviceBChecker: serviceBChecker,
+		logger:          logger,
+		cfg:             cfg,
+	}
+}
+
+func (h *HealthHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	ctx := trace.WithTraceID(r.Context())
+	traceID := trace.GetTraceID(ctx)
+
+	logger := h.logger.With(
+		zap.String("component", "HealthHandler"),
+		zap.String("method", "Handle"),
+		zap.String("trace_id", traceID),
+		zap.String("remote_addr", r.RemoteAddr),
+		zap.String("user_agent", r.UserAgent()),
+	)
+
+	logger.Debug("Iniciando verificación de salud del sistema")
+
+	response := entity.HealthResponse{
+		Status:    entity.StatusOperational,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Version:   h.cfg.AppVersion,
+	}
+
+	discordHealth, err := h.discordChecker.Check(ctx)
+	if err != nil {
+		logger.Warn("Error al verificar la salud de Discord",
+			zap.Error(err),
+		)
+		response.Discord = entity.DiscordHealth{
+			Connected: false,
+			Error:     err.Error(),
+		}
+	} else {
+		response.Discord = discordHealth
+	}
+
+	serviceBHealth, err := h.serviceBChecker.Check(ctx)
+	if err != nil {
+		logger.Warn("Error al verificar la salud de Service B",
+			zap.Error(err),
+		)
+		response.ServiceB = entity.ServiceBHealth{
+			Connected: false,
+			Error:     err.Error(),
+		}
+	} else {
+		response.ServiceB = serviceBHealth
+	}
+
+	response.Status, response.Message = entity.DetermineOverallStatus(response.Discord, response.ServiceB)
+
+	logger.Debug("Verificación de salud completada",
+		zap.String("status", string(response.Status)),
+		zap.String("message", response.Message),
+		zap.Bool("discord_connected", response.Discord.Connected),
+		zap.Bool("service_b_connected", response.ServiceB.Connected),
+		zap.Float64("duration_ms", float64(time.Since(start).Milliseconds())),
+	)
+
+	statusCode := http.StatusOK
+	switch response.Status {
+	case entity.StatusDegraded:
+		statusCode = http.StatusOK
+	case entity.StatusDown:
+		statusCode = http.StatusServiceUnavailable
+	}
+
+	w.Header().Set("Content-Type", healthCheckContentType)
+	w.Header().Set("X-Trace-ID", traceID)
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		logger.Error("Error al codificar la respuesta de salud",
+			zap.Error(err),
+		)
+		http.Error(w, "Fallo al codificar la respuesta de salud", http.StatusInternalServerError)
+		return
+	}
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/api/health_handler_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/api/health_handler_test.go
@@ -1,0 +1,239 @@
+//go:build !integration
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/adapters/api"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/config"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type MockDiscordChecker struct {
+	mock.Mock
+}
+
+func (m *MockDiscordChecker) Check(ctx context.Context) (entity.DiscordHealth, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(entity.DiscordHealth), args.Error(1)
+}
+
+type MockServiceBChecker struct {
+	mock.Mock
+}
+
+func (m *MockServiceBChecker) Check(ctx context.Context) (entity.ServiceBHealth, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(entity.ServiceBHealth), args.Error(1)
+}
+
+func TestHealthHandler_Handle_Success(t *testing.T) {
+	// Arrange
+	discordChecker := new(MockDiscordChecker)
+	serviceBChecker := new(MockServiceBChecker)
+	logger := new(logging.MockLogger)
+	cfg := &config.Config{AppVersion: "1.0.0"}
+
+	logger.On("With", mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+
+	discordHealth := entity.DiscordHealth{
+		Connected:          true,
+		HeartbeatLatencyMS: 50,
+		Guilds:             5,
+		VoiceConnections:   2,
+	}
+	discordChecker.On("Check", mock.Anything).Return(discordHealth, nil)
+
+	serviceBHealth := entity.ServiceBHealth{
+		Connected: true,
+		LatencyMS: 100,
+		Status:    "HTTP 200",
+	}
+	serviceBChecker.On("Check", mock.Anything).Return(serviceBHealth, nil)
+
+	handler := api.NewHealthHandler(discordChecker, serviceBChecker, logger, cfg)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.Handle(w, req)
+
+	// Assert
+	res := w.Result()
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+
+	var response entity.HealthResponse
+	err := json.NewDecoder(res.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, entity.StatusOperational, response.Status)
+	assert.True(t, response.Discord.Connected)
+	assert.True(t, response.ServiceB.Connected)
+	assert.Equal(t, "1.0.0", response.Version)
+
+	discordChecker.AssertExpectations(t)
+	serviceBChecker.AssertExpectations(t)
+	logger.AssertExpectations(t)
+}
+
+func TestHealthHandler_Handle_DiscordError(t *testing.T) {
+	// Arrange
+	discordChecker := new(MockDiscordChecker)
+	serviceBChecker := new(MockServiceBChecker)
+	logger := new(logging.MockLogger)
+	cfg := &config.Config{AppVersion: "1.0.0"}
+
+	logger.On("With", mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything).Return()
+
+	discordChecker.On("Check", mock.Anything).Return(entity.DiscordHealth{}, errors.New("discord error"))
+
+	serviceBHealth := entity.ServiceBHealth{
+		Connected: true,
+		LatencyMS: 100,
+		Status:    "HTTP 200",
+	}
+	serviceBChecker.On("Check", mock.Anything).Return(serviceBHealth, nil)
+
+	handler := api.NewHealthHandler(discordChecker, serviceBChecker, logger, cfg)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.Handle(w, req)
+
+	// Assert
+	res := w.Result()
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	var response entity.HealthResponse
+	err := json.NewDecoder(res.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, entity.StatusDegraded, response.Status)
+	assert.False(t, response.Discord.Connected)
+	assert.Equal(t, "discord error", response.Discord.Error)
+	assert.True(t, response.ServiceB.Connected)
+
+	discordChecker.AssertExpectations(t)
+	serviceBChecker.AssertExpectations(t)
+	logger.AssertExpectations(t)
+}
+
+func TestHealthHandler_Handle_ServiceBError(t *testing.T) {
+	// Arrange
+	discordChecker := new(MockDiscordChecker)
+	serviceBChecker := new(MockServiceBChecker)
+	logger := new(logging.MockLogger)
+	cfg := &config.Config{AppVersion: "1.0.0"}
+
+	logger.On("With", mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything).Return()
+
+	discordHealth := entity.DiscordHealth{
+		Connected:          true,
+		HeartbeatLatencyMS: 50,
+		Guilds:             5,
+		VoiceConnections:   2,
+	}
+	discordChecker.On("Check", mock.Anything).Return(discordHealth, nil)
+
+	serviceBChecker.On("Check", mock.Anything).Return(entity.ServiceBHealth{}, errors.New("service B error"))
+
+	handler := api.NewHealthHandler(discordChecker, serviceBChecker, logger, cfg)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.Handle(w, req)
+
+	// Assert
+	res := w.Result()
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	var response entity.HealthResponse
+	err := json.NewDecoder(res.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, entity.StatusDegraded, response.Status)
+	assert.True(t, response.Discord.Connected)
+	assert.False(t, response.ServiceB.Connected)
+	assert.Equal(t, "service B error", response.ServiceB.Error)
+
+	discordChecker.AssertExpectations(t)
+	serviceBChecker.AssertExpectations(t)
+	logger.AssertExpectations(t)
+}
+
+func TestHealthHandler_Handle_AllServicesDown(t *testing.T) {
+	// Arrange
+	discordChecker := new(MockDiscordChecker)
+	serviceBChecker := new(MockServiceBChecker)
+	logger := new(logging.MockLogger)
+	cfg := &config.Config{AppVersion: "1.0.0"}
+
+	logger.On("With", mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything).Return()
+
+	discordChecker.On("Check", mock.Anything).Return(entity.DiscordHealth{}, errors.New("discord error"))
+	serviceBChecker.On("Check", mock.Anything).Return(entity.ServiceBHealth{}, errors.New("service B error"))
+
+	handler := api.NewHealthHandler(discordChecker, serviceBChecker, logger, cfg)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.Handle(w, req)
+
+	// Assert
+	res := w.Result()
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	assert.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+
+	var response entity.HealthResponse
+	err := json.NewDecoder(res.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, entity.StatusDown, response.Status)
+	assert.False(t, response.Discord.Connected)
+	assert.False(t, response.ServiceB.Connected)
+
+	discordChecker.AssertExpectations(t)
+	serviceBChecker.AssertExpectations(t)
+	logger.AssertExpectations(t)
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/health/discord_checker.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/health/discord_checker.go
@@ -1,0 +1,106 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/errors_app"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
+	"github.com/bwmarrin/discordgo"
+	"go.uber.org/zap"
+	"time"
+)
+
+type DiscordChecker struct {
+	session *discordgo.Session
+	logger  logging.Logger
+}
+
+func NewDiscordChecker(session *discordgo.Session, logger logging.Logger) ports.DiscordHealthChecker {
+	return &DiscordChecker{
+		session: session,
+		logger:  logger,
+	}
+}
+
+func (d *DiscordChecker) Check(ctx context.Context) (entity.DiscordHealth, error) {
+	ctx = trace.WithTraceID(ctx)
+	traceID := trace.GetTraceID(ctx)
+
+	logger := d.logger.With(
+		zap.String("component", "DiscordChecker"),
+		zap.String("method", "Check"),
+		zap.String("trace_id", traceID),
+	)
+
+	logger.Debug("Iniciando verificación de salud de Discord")
+	start := time.Now()
+	health := entity.DiscordHealth{
+		Connected: false,
+	}
+
+	defer func() {
+		health.CheckDurationMS = float64(time.Since(start).Milliseconds())
+	}()
+
+	if d.session == nil {
+		logger.Error("La sesión de Discord es nula")
+		health.Error = "Sesión de Discord no inicializada"
+		return health, errors_app.NewAppError(
+			errors_app.ErrCodeInternalError,
+			"Sesión de Discord no inicializada",
+			nil,
+		)
+	}
+
+	health.Connected = d.session.DataReady
+	health.HeartbeatLatencyMS = d.session.HeartbeatLatency().Seconds() * 1000
+
+	guilds := 0
+	if d.session.State != nil {
+		guilds = len(d.session.State.Guilds)
+	}
+	health.Guilds = guilds
+
+	voiceConnections := 0
+	if d.session.State != nil && d.session.State.User != nil {
+		botID := d.session.State.User.ID
+		voiceStates := make(map[string]string)
+
+		for _, guild := range d.session.State.Guilds {
+			if guild.VoiceStates != nil {
+				for _, vs := range guild.VoiceStates {
+					if vs.UserID == botID && vs.ChannelID != "" {
+						voiceStates[guild.ID] = vs.ChannelID
+						voiceConnections++
+					}
+				}
+			}
+		}
+	}
+	health.VoiceConnections = voiceConnections
+
+	if d.session.State != nil {
+		health.SessionID = d.session.State.SessionID
+	}
+
+	if !health.Connected {
+		logger.Warn("Discord no está conectado")
+		health.Error = "WebSocket no conectado"
+	} else if health.HeartbeatLatencyMS > 1000 {
+		logger.Warn("Discord tiene alta latencia",
+			zap.Float64("heartbeat_latency_ms", health.HeartbeatLatencyMS),
+		)
+		health.Error = fmt.Sprintf("Alta latencia: %.2f ms", health.HeartbeatLatencyMS)
+	} else {
+		logger.Debug("Discord está saludable",
+			zap.Float64("heartbeat_latency_ms", health.HeartbeatLatencyMS),
+			zap.Int("guilds", health.Guilds),
+			zap.Int("voice_connections", health.VoiceConnections),
+		)
+	}
+
+	return health, nil
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/health/discord_checker_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/health/discord_checker_test.go
@@ -1,0 +1,234 @@
+//go:build !integration
+
+package health_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/adapters/health"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+func TestDiscordChecker_Check_SessionNil(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Error", mock.Anything, mock.Anything).Return()
+
+	checker := health.NewDiscordChecker(nil, logger)
+
+	// Act
+	h, err := checker.Check(context.Background())
+
+	// Assert
+	assert.False(t, h.Connected)
+	assert.Equal(t, "Sesión de Discord no inicializada", h.Error)
+	assert.NotNil(t, err)
+	logger.AssertExpectations(t)
+}
+
+func TestDiscordChecker_Check_Success(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+	session := &discordgo.Session{
+		State: &discordgo.State{
+			Ready: discordgo.Ready{
+				SessionID: "test_session_id",
+				User: &discordgo.User{
+					ID: "bot_user_id",
+				},
+				Guilds: []*discordgo.Guild{
+					{
+						ID: "guild1",
+						VoiceStates: []*discordgo.VoiceState{
+							{
+								UserID:    "bot_user_id",
+								ChannelID: "channel1",
+							},
+							{
+								UserID:    "other_user",
+								ChannelID: "channel2",
+							},
+						},
+					},
+					{
+						ID: "guild2",
+						VoiceStates: []*discordgo.VoiceState{
+							{
+								UserID:    "bot_user_id",
+								ChannelID: "channel3",
+							},
+						},
+					},
+					{
+						ID:          "guild3",
+						VoiceStates: []*discordgo.VoiceState{},
+					},
+				},
+			},
+		},
+	}
+
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+
+	session.DataReady = true
+	now := time.Now()
+	session.LastHeartbeatSent = now.Add(-500 * time.Millisecond)
+	session.LastHeartbeatAck = now
+
+	checker := health.NewDiscordChecker(session, logger)
+
+	// Act
+	h, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, h.Connected)
+	assert.InDelta(t, 500.0, h.HeartbeatLatencyMS, 10.0)
+	assert.Equal(t, 3, h.Guilds)
+	assert.Equal(t, 2, h.VoiceConnections)
+	fmt.Println(h.CheckDurationMS)
+	assert.Equal(t, "test_session_id", h.SessionID)
+	assert.GreaterOrEqual(t, h.CheckDurationMS, 0.0)
+	if h.CheckDurationMS == 0 {
+		t.Log("CheckDurationMS es 0, puede ser demasiado rápido para medir")
+	}
+	assert.Empty(t, h.Error)
+}
+
+func TestDiscordChecker_Check_NotConnected(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+	session := &discordgo.Session{
+		State: &discordgo.State{
+			Ready: discordgo.Ready{
+				SessionID: "test_session_id",
+				User: &discordgo.User{
+					ID: "bot_user_id",
+				},
+				Guilds: []*discordgo.Guild{},
+			},
+		},
+	}
+
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything).Return()
+
+	session.DataReady = false
+
+	checker := health.NewDiscordChecker(session, logger)
+
+	// Act
+	h, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.False(t, h.Connected)
+	assert.Equal(t, "WebSocket no conectado", h.Error)
+	assert.GreaterOrEqual(t, h.CheckDurationMS, 0.0, "CheckDurationMS debería ser mayor o igual que cero")
+
+}
+
+func TestDiscordChecker_Check_HighLatency(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+	session := &discordgo.Session{
+		State: &discordgo.State{
+			Ready: discordgo.Ready{
+				SessionID: "test_session_id",
+				User: &discordgo.User{
+					ID: "bot_user_id",
+				},
+				Guilds: []*discordgo.Guild{},
+			},
+		},
+	}
+
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything).Return()
+
+	session.DataReady = true
+	now := time.Now()
+	session.LastHeartbeatSent = now.Add(-1500 * time.Millisecond)
+	session.LastHeartbeatAck = now
+
+	checker := health.NewDiscordChecker(session, logger)
+
+	// Act
+	h, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, h.Connected)
+	assert.InDelta(t, 1500.0, h.HeartbeatLatencyMS, 10.0)
+	assert.Contains(t, h.Error, "Alta latencia")
+	assert.GreaterOrEqual(t, h.CheckDurationMS, 0.0, "CheckDurationMS debería ser mayor o igual que cero")
+
+}
+
+func TestDiscordChecker_Check_NoVoiceConnections(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+	session := &discordgo.Session{
+		State: &discordgo.State{
+			Ready: discordgo.Ready{
+				SessionID: "test_session_id",
+				User: &discordgo.User{
+					ID: "bot_user_id",
+				},
+				Guilds: []*discordgo.Guild{
+					{
+						ID: "guild1",
+						VoiceStates: []*discordgo.VoiceState{
+							{
+								UserID:    "other_user1",
+								ChannelID: "channel1",
+							},
+							{
+								UserID:    "other_user2",
+								ChannelID: "channel2",
+							},
+						},
+					},
+					{
+						ID:          "guild2",
+						VoiceStates: []*discordgo.VoiceState{},
+					},
+				},
+			},
+		},
+	}
+
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+
+	session.DataReady = true
+	now := time.Now()
+	session.LastHeartbeatSent = now.Add(-100 * time.Millisecond)
+	session.LastHeartbeatAck = now
+
+	checker := health.NewDiscordChecker(session, logger)
+
+	// Act
+	h, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, h.Connected)
+	assert.InDelta(t, 100.0, h.HeartbeatLatencyMS, 10.0)
+	assert.Equal(t, 2, h.Guilds)
+	assert.Equal(t, 0, h.VoiceConnections)
+	assert.Empty(t, h.Error)
+	assert.GreaterOrEqual(t, h.CheckDurationMS, 0.0, "CheckDurationMS debería ser mayor o igual que cero")
+
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/health/service_b_checker.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/health/service_b_checker.go
@@ -1,0 +1,156 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/errors_app"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
+	"go.uber.org/zap"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	defaultTimeout     = 10 * time.Second
+	healthCheckTimeout = 5 * time.Second
+	idleConnTimeout    = 90 * time.Second
+	healthEndpointPath = "api/v1/health"
+)
+
+type ServiceConfig struct {
+	BaseURL         string
+	Timeout         time.Duration
+	MaxIdleConns    int
+	MaxConnsPerHost int
+}
+
+type ServiceBChecker struct {
+	client  *http.Client
+	baseURL *url.URL
+	logger  logging.Logger
+}
+
+func NewServiceBChecker(config *ServiceConfig, logger logging.Logger) (ports.ServiceBHealthChecker, error) {
+	if config == nil {
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInvalidInput, "La configuración del servicio no puede ser nula", nil)
+	}
+
+	if config.BaseURL == "" {
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInvalidInput, "La URL base no puede estar vacía", nil)
+	}
+
+	timeout := config.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	baseURL, err := url.Parse(config.BaseURL)
+	if err != nil {
+		return nil, errors_app.NewAppError(errors_app.ErrCodeInvalidInput, "La URL base no es válida", err)
+	}
+
+	maxIdleConns := config.MaxIdleConns
+	if maxIdleConns <= 0 {
+		maxIdleConns = 10
+	}
+
+	maxConnsPerHost := config.MaxConnsPerHost
+	if maxConnsPerHost <= 0 {
+		maxConnsPerHost = 10
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:    maxIdleConns,
+		MaxConnsPerHost: maxConnsPerHost,
+		IdleConnTimeout: idleConnTimeout,
+	}
+
+	return &ServiceBChecker{
+		baseURL: baseURL,
+		logger:  logger,
+		client: &http.Client{
+			Timeout:   timeout,
+			Transport: transport,
+		},
+	}, nil
+}
+
+func (s *ServiceBChecker) Check(ctx context.Context) (entity.ServiceBHealth, error) {
+	ctx = trace.WithTraceID(ctx)
+	traceID := trace.GetTraceID(ctx)
+
+	logger := s.logger.With(
+		zap.String("component", "ServiceBChecker"),
+		zap.String("method", "Check"),
+		zap.String("trace_id", traceID),
+	)
+
+	logger.Debug("Iniciando verificación de salud de Service B")
+	start := time.Now()
+
+	endpoint := s.baseURL.JoinPath(healthEndpointPath)
+
+	ctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		logger.Error("Error al crear la petición HTTP",
+			zap.String("endpoint", endpoint.String()),
+			zap.Error(err),
+		)
+		return entity.ServiceBHealth{}, errors_app.NewAppError(
+			errors_app.ErrCodeInternalError,
+			"Error al crear la petición HTTP",
+			err,
+		)
+	}
+
+	resp, err := s.client.Do(req)
+	latency := time.Since(start).Milliseconds()
+
+	if err != nil {
+		logger.Warn("Error al conectar con Service B",
+			zap.String("endpoint", endpoint.String()),
+			zap.Int64("latency_ms", latency),
+			zap.Error(err),
+		)
+		return entity.ServiceBHealth{
+			Connected: false,
+			LatencyMS: int(latency),
+			Error:     fmt.Sprintf("Error de conexión: %v", err),
+		}, nil
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error("Error al cerrar el cuerpo de la respuesta", zap.Error(err))
+		}
+	}()
+
+	connected := resp.StatusCode == http.StatusOK
+	statusText := fmt.Sprintf("HTTP %d", resp.StatusCode)
+
+	health := entity.ServiceBHealth{
+		Connected: connected,
+		LatencyMS: int(latency),
+		Status:    statusText,
+	}
+
+	if !connected {
+		logger.Warn("Service B devolvió un estado no saludable",
+			zap.Int("status_code", resp.StatusCode),
+			zap.Int64("latency_ms", latency),
+		)
+	} else {
+		logger.Debug("Service B está saludable",
+			zap.Int("status_code", resp.StatusCode),
+			zap.Int64("latency_ms", latency),
+		)
+	}
+	return health, nil
+}

--- a/microservices/butakero_bot/internal/infrastructure/adapters/health/service_b_checker_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/adapters/health/service_b_checker_test.go
@@ -1,0 +1,162 @@
+//go:build !integration
+
+package health_test
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/adapters/health"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type MockHTTPClient struct {
+	mock.Mock
+}
+
+func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	args := m.Called(req)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+func TestNewServiceBChecker_InvalidConfig(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+
+	// Act
+	checker, err := health.NewServiceBChecker(nil, logger)
+
+	// Assert
+	assert.Nil(t, checker)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "La configuración del servicio no puede ser nula")
+}
+
+func TestNewServiceBChecker_InvalidURL(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+	config := &health.ServiceConfig{
+		BaseURL: "://invalid-url",
+	}
+
+	// Act
+	checker, err := health.NewServiceBChecker(config, logger)
+
+	// Assert
+	assert.Nil(t, checker)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "La URL base no es válida")
+}
+
+func TestServiceBChecker_Check_Success(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/health", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := new(logging.MockLogger)
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+
+	config := &health.ServiceConfig{
+		BaseURL: server.URL,
+	}
+	checker, _ := health.NewServiceBChecker(config, logger)
+
+	// Act
+	result, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, result.Connected)
+	assert.Equal(t, "HTTP 200", result.Status)
+	assert.GreaterOrEqual(t, result.LatencyMS, 0)
+	logger.AssertExpectations(t)
+}
+
+func TestServiceBChecker_Check_Unhealthy(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	logger := new(logging.MockLogger)
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything).Return()
+
+	config := &health.ServiceConfig{
+		BaseURL: server.URL,
+	}
+	checker, _ := health.NewServiceBChecker(config, logger)
+
+	// Act
+	result, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.False(t, result.Connected)
+	assert.Equal(t, "HTTP 500", result.Status)
+	assert.GreaterOrEqual(t, result.LatencyMS, 0)
+	logger.AssertExpectations(t)
+}
+
+func TestServiceBChecker_Check_ConnectionError(t *testing.T) {
+	// Arrange
+	logger := new(logging.MockLogger)
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	config := &health.ServiceConfig{
+		BaseURL: "http://unreachable-server",
+	}
+	checker, _ := health.NewServiceBChecker(config, logger)
+
+	// Act
+	result, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.False(t, result.Connected)
+	assert.Contains(t, result.Error, "Error de conexión")
+	assert.Greater(t, result.LatencyMS, 0)
+	logger.AssertExpectations(t)
+}
+
+func TestServiceBChecker_Check_Timeout(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := new(logging.MockLogger)
+	logger.On("With", mock.Anything, mock.Anything).Return(logger)
+	logger.On("Debug", mock.Anything, mock.Anything).Return()
+	logger.On("Warn", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	config := &health.ServiceConfig{
+		BaseURL: server.URL,
+		Timeout: 100 * time.Millisecond,
+	}
+	checker, _ := health.NewServiceBChecker(config, logger)
+
+	// Act
+	result, err := checker.Check(context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.False(t, result.Connected)
+	assert.Contains(t, result.Error, "context deadline exceeded")
+	assert.Greater(t, result.LatencyMS, 0)
+	logger.AssertExpectations(t)
+}

--- a/microservices/butakero_bot/internal/shared/config/config.go
+++ b/microservices/butakero_bot/internal/shared/config/config.go
@@ -20,6 +20,7 @@ type (
 		QueueConfig     QueueConfig
 		DatabaseConfig  DatabaseConfig
 		ExternalService ExternalService
+		AppVersion      string
 	}
 
 	DatabaseConfig struct {
@@ -125,6 +126,7 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault("MONGO_RETRY_WRITES", true)
 	viper.SetDefault("LOCAL_STORAGE_DIRECTORY", "/app/data/audio-files")
 	viper.SetDefault("AUDIO_PROCESSOR_URL", "http://localhost:8080")
+	viper.SetDefault("APP_VERSION", "1.0.0")
 
 	var mongoHosts []Host
 	for _, host := range viper.GetStringSlice("MONGO_HOSTS") {
@@ -135,6 +137,7 @@ func LoadConfig() (*Config, error) {
 	}
 
 	cfg := &Config{
+		AppVersion:    viper.GetString("APP_VERSION"),
 		CommandPrefix: viper.GetString("COMMAND_PREFIX"),
 		QueueConfig: QueueConfig{
 			KafkaConfig: KafkaConfig{
@@ -205,6 +208,7 @@ func LoadConfigAws() (*Config, error) {
 	}
 
 	cfg := &Config{
+		AppVersion:    secrets["APP_VERSION"],
 		CommandPrefix: secrets["COMMAND_PREFIX"],
 		Discord: Discord{
 			Token: secrets["DISCORD_TOKEN"],


### PR DESCRIPTION
- **Implement health check endpoint (/api/v1/health):** Adds a new endpoint to expose the bot's health status. This allows for monitoring and automated health checks.
- **Introduce health checkers for Discord and Service B:** Creates dedicated checkers for the Discord connection and the external Service B. This improves the accuracy and granularity of the health information.
- **Include application version in health response:** Adds the application version to the health response. Enables easier identification of the running bot version.