### PR TITLE
feat: Add Discord bot K8s manifests and sample audio files

### DIFF
--- a/k8s/bases/backend/discord-bot/configmap.yaml
+++ b/k8s/bases/backend/discord-bot/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: discord-bot-config
+  namespace: backend
+data:
+  COMMAND_PREFIX: "test"
+  KAFKA_TLS_CA_FILE: "/etc/kafka/ca-certs/ca.crt"
+  KAFKA_TLS_CERT_FILE: "/etc/kafka/user-certs/user.crt"
+  KAFKA_TLS_KEY_FILE: "/etc/kafka/user-certs/user.key"
+  KAFKA_TLS_ENABLED: "true"
+  KAFKA_BROKERS: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093"
+  KAFKA_BOT_DOWNLOAD_STATUS: "bot.download.status"
+  KAFKA_BOT_DOWNLOAD_REQUESTS: "bot.download.requests"
+  LOCAL_STORAGE_DIRECTORY: "/shared-audio"
+  AUDIO_PROCESSOR_URL: "http://audio-processing-service.backend.svc.cluster.local:8080"

--- a/k8s/bases/backend/discord-bot/deployment.yaml
+++ b/k8s/bases/backend/discord-bot/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: discord-bot
+  namespace: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: discord-bot
+  template:
+    metadata:
+      labels:
+        app: discord-bot
+    spec:
+      containers:
+        - name: discord-bot
+          volumeMounts:
+            - name: audio-storage
+              mountPath: /shared-audio
+            - name: kafka-user-cert
+              mountPath: /etc/kafka/user-certs
+              readOnly: true
+            - name: kafka-ca-cert
+              mountPath: /etc/kafka/ca-certs
+              readOnly: true
+          image: tomasvilte/butakero_bot:1.1.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8081
+          envFrom:
+            - configMapRef:
+                name: discord-bot-config
+            - secretRef:
+                name: discord-bot-secrets
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 150m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: audio-storage
+          persistentVolumeClaim:
+            claimName: audio-files-pvc
+        - name: kafka-user-cert
+          secret:
+            secretName: my-kafka-user
+            items:
+              - key: user.crt
+                path: user.crt
+              - key: user.key
+                path: user.key
+        - name: kafka-ca-cert
+          secret:
+            secretName: kafka-server-cert
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/k8s/bases/backend/discord-bot/secret.yaml
+++ b/k8s/bases/backend/discord-bot/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: discord-bot-secrets
+  namespace: backend
+type: Opaque
+stringData:
+  DISCORD_TOKEN: ""

--- a/k8s/bases/backend/discord-bot/service.yaml
+++ b/k8s/bases/backend/discord-bot/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: discord-bot-service
+  namespace: backend
+  labels:
+    app: discord-bot
+    component: bot
+spec:
+  selector:
+    app: discord-bot
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/k8s/bases/backend/download-service/pvc.yaml
+++ b/k8s/bases/backend/download-service/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audio-files-pvc
+  namespace: backend
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: standard


### PR DESCRIPTION
- **Adds K8s manifests for the Discord bot:** Defines the deployment, service, configmap, and secrets required to run the Discord bot in a Kubernetes cluster. Purpose: To containerize and orchestrate the Discord bot deployment. Technical Impact: Enables scalable and resilient bot deployment.
- **Adds a PersistentVolumeClaim for audio files:** Creates a PVC named `audio-files-pvc` to provide persistent storage for audio files used by the bot. Purpose: To ensure audio files are stored reliably and accessible across bot restarts. Technical Impact: Audio files survive pod restarts.
- **Configures Kafka TLS:** Specifies settings related to Kafka certificates and connection parameters to enable secure connection to Kafka broker. Purpose: To ensure secure communication between the Discord bot and the Kafka broker using TLS. Technical Impact: Enhanced data security during bot operation.