### PR TITLE
refactor: Enhance audio processing pipeline with encoding and size limits

### DIFF
--- a/microservices/audio_processor/cmd/aws/server/server.go
+++ b/microservices/audio_processor/cmd/aws/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
 	"io"
 	"net/http"
 	"os"
@@ -102,7 +103,7 @@ func StartServer() error {
 
 	encoderAudio := encoder.NewFFmpegEncoder(log)
 	audioStorageService := service.NewAudioStorageService(storage, log)
-	audioDownloadService := service.NewAudioDownloaderService(downloaderMusic, encoderAudio, log)
+	audioDownloadService := service.NewAudioDownloaderService(downloaderMusic, encoderAudio, log, model.StdEncodeOptions)
 	coreService := service.NewCoreService(mediaRepository, audioStorageService, sqsProducer, audioDownloadService, log, cfg)
 	providerService := service.NewVideoService(providers, log)
 	healthCheck := controller.NewHealthHandler(cfg)

--- a/microservices/audio_processor/cmd/local/server/server.go
+++ b/microservices/audio_processor/cmd/local/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
 	"net/http"
 	"os"
 	"os/signal"
@@ -106,7 +107,7 @@ func StartServer() error {
 	}
 
 	audioStorageService := service.NewAudioStorageService(storage, log)
-	audioDownloadService := service.NewAudioDownloaderService(downloaderMusic, encoderAudio, log)
+	audioDownloadService := service.NewAudioDownloaderService(downloaderMusic, encoderAudio, log, model.StdEncodeOptions)
 	coreService := service.NewCoreService(mediaRepository, audioStorageService, kafkaProducer, audioDownloadService, log, cfg)
 	providerService := service.NewVideoService(providers, log)
 	healthCheck := controller.NewHealthHandler(cfg)

--- a/microservices/audio_processor/internal/domain/service/audio_downloader_service.go
+++ b/microservices/audio_processor/internal/domain/service/audio_downloader_service.go
@@ -3,45 +3,74 @@ package service
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/ports"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"go.uber.org/zap"
 	"io"
+	"time"
 )
 
 type audioDownloaderService struct {
-	downloader ports.Downloader
-	encoder    ports.AudioEncoder
-	log        logger.Logger
+	downloader    ports.Downloader
+	encoder       ports.AudioEncoder
+	encodeOptions *model.EncodeOptions
+	maxAudioSize  int
+	log           logger.Logger
 }
 
-func NewAudioDownloaderService(d ports.Downloader, e ports.AudioEncoder, l logger.Logger) ports.AudioDownloadService {
+func NewAudioDownloaderService(d ports.Downloader, e ports.AudioEncoder, l logger.Logger, encodeOptions *model.EncodeOptions) ports.AudioDownloadService {
 	return &audioDownloaderService{
-		downloader: d,
-		encoder:    e,
-		log:        l,
+		downloader:    d,
+		encoder:       e,
+		log:           l,
+		encodeOptions: encodeOptions,
+		maxAudioSize:  100 * 1024 * 1024,
 	}
 }
 
 func (ad *audioDownloaderService) DownloadAndEncode(ctx context.Context, url string) (*bytes.Buffer, error) {
+	log := ad.log.With(
+		zap.String("component", "AudioDownloaderService"),
+		zap.String("method", "DownloadAndEncode"),
+		zap.String("url", url),
+	)
+	startTime := time.Now()
+
 	reader, err := ad.downloader.DownloadAudio(ctx, url)
 	if err != nil {
+		log.Error("Error en descarga", zap.Error(err))
 		return nil, err
 	}
 
-	session, err := ad.encoder.Encode(ctx, reader, model.StdEncodeOptions)
+	session, err := ad.encoder.Encode(ctx, reader, ad.encodeOptions)
 	if err != nil {
+		log.Error("Error en codificación", zap.Error(err))
 		return nil, err
 	}
 	defer session.Cleanup()
 
-	return ad.readAudioFramesToBuffer(session)
+	buffer, err := ad.readAudioFramesToBuffer(session)
+	if err != nil {
+		log.Error("Error al leer frames", zap.Error(err))
+		return nil, err
+	}
+
+	log.Info("Audio procesado",
+		zap.Int("size_bytes", buffer.Len()),
+		zap.Duration("duration", time.Since(startTime)),
+	)
+	return buffer, nil
 }
 
 func (ad *audioDownloaderService) readAudioFramesToBuffer(session ports.EncodeSession) (*bytes.Buffer, error) {
 	var buffer bytes.Buffer
 
 	for {
+		if buffer.Len() > ad.maxAudioSize {
+			return nil, fmt.Errorf("el tamaño máximo de audio (%d bytes) ha sido superado", ad.maxAudioSize)
+		}
 		frame, err := session.ReadFrame()
 		if err == io.EOF {
 			break

--- a/microservices/audio_processor/internal/domain/service/audio_storage_service.go
+++ b/microservices/audio_processor/internal/domain/service/audio_storage_service.go
@@ -10,6 +10,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const audioFileExtension = ".dca"
+
 type audioStorageService struct {
 	storage ports.Storage
 	log     logger.Logger
@@ -28,8 +30,12 @@ func (as *audioStorageService) StoreAudio(ctx context.Context, buffer *bytes.Buf
 		zap.String("method", "StoreAudio"),
 		zap.String("songName", songName),
 	)
-	keyName := fmt.Sprintf("%s%s", songName, ".dca")
 
+	if songName == "" {
+		return nil, fmt.Errorf("songName no puede ser vacío")
+	}
+
+	keyName := songName + audioFileExtension
 	if err := as.storage.UploadFile(ctx, keyName, buffer); err != nil {
 		log.Error("Error al subir el archivo", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
- **Pass EncodeOptions to AudioDownloaderService:** The `NewAudioDownloaderService` now receives `model.EncodeOptions` to configure audio encoding, allowing for customizable encoding parameters. This changes the service signature in `server.go` files for both AWS and local setups.
- **Implement audio size limit:** The `readAudioFramesToBuffer` function now checks if the audio buffer exceeds `maxAudioSize` (100MB).  If it does, it returns an error, preventing excessively large audio files from being processed.
- **Add default extension for file name:** The `StoreAudio` function now appends the `.dca` extension to the songName before uploading it to storage.

**Purpose of each one:**
- **EncodeOptions:** To make the audio encoding more flexible and configurable.
- **Audio Size Limit:**  To prevent the application from crashing or consuming excessive resources when processing very large audio files.
- **Extension for filename:** ensure all file names have the correct extension

**Technical impact if applicable:**
- The change in the `NewAudioDownloaderService` signature requires updating its instantiation in the server setup.
- Introduces a potential error case where audio processing fails due to exceeding the size limit.