### PR TITLE
refactor: Mock audio processing, correct FFmpeg spelling, add worker tests

### DIFF
--- a/microservices/audio_processor/cmd/aws/server/server.go
+++ b/microservices/audio_processor/cmd/aws/server/server.go
@@ -101,7 +101,7 @@ func StartServer() error {
 		"youtube": youtubeAPI,
 	}
 
-	encoderAudio := encoder.NewFFmpegEncoder(log)
+	encoderAudio := encoder.NewFFMPEGEncoder(log)
 	audioStorageService := service.NewAudioStorageService(storage, log)
 	audioDownloadService := service.NewAudioDownloaderService(downloaderMusic, encoderAudio, log, model.StdEncodeOptions)
 	coreService := service.NewCoreService(mediaRepository, audioStorageService, sqsProducer, audioDownloadService, log, cfg)

--- a/microservices/audio_processor/cmd/local/server/server.go
+++ b/microservices/audio_processor/cmd/local/server/server.go
@@ -101,7 +101,7 @@ func StartServer() error {
 	}
 
 	youtubeAPI := adapters.NewYouTubeClient(cfg.API.YouTube.ApiKey, log)
-	encoderAudio := encoder.NewFFmpegEncoder(log)
+	encoderAudio := encoder.NewFFMPEGEncoder(log)
 	providers := map[string]ports.VideoProvider{
 		"youtube": youtubeAPI,
 	}

--- a/microservices/audio_processor/internal/domain/service/audio_downloader_service_test.go
+++ b/microservices/audio_processor/internal/domain/service/audio_downloader_service_test.go
@@ -1,0 +1,195 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestAudioDownloaderService_DownloadAndEncode_Success(t *testing.T) {
+	ctx := context.Background()
+	testURL := "https://test.com/audio.mp3"
+	testAudioContent := "test audio content"
+	testEncodeOptions := model.StdEncodeOptions
+
+	mockDownloader := new(MockDownloader)
+	mockEncoder := new(MockAudioEncoder)
+	mockEncodeSession := new(MockEncodeSession)
+	mockLogger := new(logger.MockLogger)
+
+	mockLogger.On("With", mock.Anything, mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+
+	mockDownloader.On("DownloadAudio", ctx, testURL).Return(
+		strings.NewReader(testAudioContent), nil)
+
+	mockEncoder.On("Encode", ctx, mock.AnythingOfType("*strings.Reader"), testEncodeOptions).Return(
+		mockEncodeSession, nil)
+
+	frame1 := []byte("frame1")
+	frame2 := []byte("frame2")
+
+	mockEncodeSession.On("ReadFrame").Return(frame1, nil).Once()
+	mockEncodeSession.On("ReadFrame").Return(frame2, nil).Once()
+	mockEncodeSession.On("ReadFrame").Return([]byte{}, io.EOF).Once()
+	mockEncodeSession.On("Cleanup").Return()
+
+	service := NewAudioDownloaderService(mockDownloader, mockEncoder, mockLogger, testEncodeOptions)
+
+	buffer, err := service.DownloadAndEncode(ctx, testURL)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, buffer)
+	assert.Equal(t, append(frame1, frame2...), buffer.Bytes())
+
+	mockDownloader.AssertExpectations(t)
+	mockEncoder.AssertExpectations(t)
+	mockEncodeSession.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestAudioDownloaderService_DownloadAndEncode_DownloadError(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	testURL := "https://test.com/invalid.mp3"
+	testEncodeOptions := model.StdEncodeOptions
+	expectedErr := errors.New("download failed")
+
+	mockDownloader := new(MockDownloader)
+	mockEncoder := new(MockAudioEncoder)
+	mockLogger := new(logger.MockLogger)
+
+	mockLogger.On("With", mock.Anything, mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockDownloader.On("DownloadAudio", ctx, testURL).Return(nil, expectedErr)
+
+	service := NewAudioDownloaderService(mockDownloader, mockEncoder, mockLogger, testEncodeOptions)
+
+	buffer, err := service.DownloadAndEncode(ctx, testURL)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, buffer)
+
+	mockDownloader.AssertExpectations(t)
+	mockEncoder.AssertNotCalled(t, "Encode")
+	mockLogger.AssertExpectations(t)
+}
+
+func TestAudioDownloaderService_DownloadAndEncode_EncodeError(t *testing.T) {
+	ctx := context.Background()
+	testURL := "https://test.com/audio.mp3"
+	testAudioContent := "test audio content"
+	testEncodeOptions := model.StdEncodeOptions
+	expectedErr := errors.New("encode failed")
+
+	mockDownloader := new(MockDownloader)
+	mockEncoder := new(MockAudioEncoder)
+	mockLogger := new(logger.MockLogger)
+
+	mockLogger.On("With", mock.Anything, mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockDownloader.On("DownloadAudio", ctx, testURL).Return(
+		strings.NewReader(testAudioContent), nil)
+
+	mockEncoder.On("Encode", ctx, mock.AnythingOfType("*strings.Reader"), testEncodeOptions).Return(
+		nil, expectedErr)
+
+	service := NewAudioDownloaderService(mockDownloader, mockEncoder, mockLogger, testEncodeOptions)
+
+	buffer, err := service.DownloadAndEncode(ctx, testURL)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, buffer)
+
+	mockDownloader.AssertExpectations(t)
+	mockEncoder.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestAudioDownloaderService_DownloadAndEncode_ReadFrameError(t *testing.T) {
+	ctx := context.Background()
+	testURL := "https://test.com/audio.mp3"
+	testAudioContent := "test audio content"
+	testEncodeOptions := model.StdEncodeOptions
+	expectedErr := errors.New("read frame failed")
+
+	mockDownloader := new(MockDownloader)
+	mockEncoder := new(MockAudioEncoder)
+	mockEncodeSession := new(MockEncodeSession)
+	mockLogger := new(logger.MockLogger)
+
+	mockLogger.On("With", mock.Anything, mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockDownloader.On("DownloadAudio", ctx, testURL).Return(
+		strings.NewReader(testAudioContent), nil)
+
+	mockEncoder.On("Encode", ctx, mock.AnythingOfType("*strings.Reader"), testEncodeOptions).Return(
+		mockEncodeSession, nil)
+
+	mockEncodeSession.On("ReadFrame").Return(nil, expectedErr)
+	mockEncodeSession.On("Cleanup").Return()
+
+	service := NewAudioDownloaderService(mockDownloader, mockEncoder, mockLogger, testEncodeOptions)
+
+	buffer, err := service.DownloadAndEncode(ctx, testURL)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, buffer)
+
+	mockDownloader.AssertExpectations(t)
+	mockEncoder.AssertExpectations(t)
+	mockEncodeSession.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestAudioDownloaderService_DownloadAndEncode_MaxSizeExceeded(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	testURL := "https://test.com/audio.mp3"
+	testAudioContent := "test audio content"
+	testEncodeOptions := model.StdEncodeOptions
+
+	mockDownloader := new(MockDownloader)
+	mockEncoder := new(MockAudioEncoder)
+	mockEncodeSession := new(MockEncodeSession)
+	mockLogger := new(logger.MockLogger)
+
+	mockLogger.On("With", mock.Anything, mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockDownloader.On("DownloadAudio", ctx, testURL).Return(
+		strings.NewReader(testAudioContent), nil)
+
+	mockEncoder.On("Encode", ctx, mock.AnythingOfType("*strings.Reader"), testEncodeOptions).Return(
+		mockEncodeSession, nil)
+
+	largeFrame := make([]byte, 101*1024*1024)
+
+	mockEncodeSession.On("ReadFrame").Return(largeFrame, nil)
+	mockEncodeSession.On("Cleanup").Return()
+
+	service := NewAudioDownloaderService(mockDownloader, mockEncoder, mockLogger, testEncodeOptions)
+
+	buffer, err := service.DownloadAndEncode(ctx, testURL)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tamaño máximo de audio")
+	assert.Nil(t, buffer)
+
+	mockDownloader.AssertExpectations(t)
+	mockEncoder.AssertExpectations(t)
+	mockEncodeSession.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}

--- a/microservices/audio_processor/internal/domain/service/mocks.go
+++ b/microservices/audio_processor/internal/domain/service/mocks.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/ports"
 	"github.com/stretchr/testify/mock"
 	"io"
 )
@@ -30,6 +31,18 @@ type (
 	}
 
 	MockAudioDownloadService struct {
+		mock.Mock
+	}
+
+	MockDownloader struct {
+		mock.Mock
+	}
+
+	MockAudioEncoder struct {
+		mock.Mock
+	}
+
+	MockEncodeSession struct {
 		mock.Mock
 	}
 )
@@ -102,4 +115,47 @@ func (m *MockAudioStorageService) StoreAudio(ctx context.Context, buffer *bytes.
 func (m *MockAudioDownloadService) DownloadAndEncode(ctx context.Context, url string) (*bytes.Buffer, error) {
 	args := m.Called(ctx, url)
 	return args.Get(0).(*bytes.Buffer), args.Error(1)
+}
+
+func (m *MockDownloader) DownloadAudio(ctx context.Context, url string) (io.Reader, error) {
+	args := m.Called(ctx, url)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(io.Reader), args.Error(1)
+}
+
+func (m *MockAudioEncoder) Encode(ctx context.Context, reader io.Reader, options *model.EncodeOptions) (ports.EncodeSession, error) {
+	args := m.Called(ctx, reader, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(ports.EncodeSession), args.Error(1)
+}
+
+func (m *MockEncodeSession) ReadFrame() ([]byte, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockEncodeSession) Read(p []byte) (n int, err error) {
+	args := m.Called(p)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockEncodeSession) Stop() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockEncodeSession) FFMPEGMessages() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockEncodeSession) Cleanup() {
+	m.Called()
 }

--- a/microservices/audio_processor/internal/domain/service/video_service.go
+++ b/microservices/audio_processor/internal/domain/service/video_service.go
@@ -32,6 +32,10 @@ func (s *videoService) GetMediaDetails(ctx context.Context, input string, provid
 		zap.String("providerType", providerType),
 	)
 
+	if input == "" || providerType == "" {
+		return nil, errors.ErrInvalidInput.WithMessage("El input y el tipo de proveedor no pueden estar vacíos")
+	}
+
 	providerTypeLower := strings.ToLower(providerType)
 	provider, ok := s.providers[providerTypeLower]
 	if !ok {
@@ -42,14 +46,14 @@ func (s *videoService) GetMediaDetails(ctx context.Context, input string, provid
 	videoID, err := provider.SearchVideoID(ctx, input)
 	if err != nil {
 		log.Error("Error al buscar ID de video", zap.Error(err), zap.String("provider_type", providerType))
-		return nil, err
+		return nil, errors.ErrCodeSearchVideoIDFailed.Wrap(err)
 	}
 
 	log.Debug("Obteniendo detalles de la cancion", zap.String("provider_type", providerType), zap.String("video_id", videoID))
 	mediaDetails, err := provider.GetVideoDetails(ctx, videoID)
 	if err != nil {
 		log.Error("Error al obtener detalles del medio", zap.Error(err), zap.String("provider_type", providerType), zap.String("video_id", videoID))
-		return nil, err
+		return nil, errors.ErrGetMediaDetailsFailed.Wrap(err)
 	}
 	return mediaDetails, nil
 }

--- a/microservices/audio_processor/internal/infrastructure/encoder/encoder_benchmark_test.go
+++ b/microservices/audio_processor/internal/infrastructure/encoder/encoder_benchmark_test.go
@@ -34,7 +34,7 @@ func BenchmarkAudioEncoding(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			log, err := logger.NewDevelopmentLogger()
 			require.NoError(b, err)
-			ffmpegEncoder := encoder.NewFFmpegEncoder(log)
+			ffmpegEncoder := encoder.NewFFMPEGEncoder(log)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -81,7 +81,7 @@ func BenchmarkResourceUsage(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			log, err := logger.NewDevelopmentLogger()
 			require.NoError(b, err)
-			ffmpegEncoder := encoder.NewFFmpegEncoder(log)
+			ffmpegEncoder := encoder.NewFFMPEGEncoder(log)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/microservices/audio_processor/internal/infrastructure/encoder/encoder_test.go
+++ b/microservices/audio_processor/internal/infrastructure/encoder/encoder_test.go
@@ -26,7 +26,7 @@ func TestEncoder(t *testing.T) {
 		}
 	}()
 
-	sessionEncoder := NewFFmpegEncoder(logging)
+	sessionEncoder := NewFFMPEGEncoder(logging)
 
 	session, err := sessionEncoder.Encode(ctx, inputFile, model.StdEncodeOptions)
 	if err != nil {

--- a/microservices/audio_processor/internal/worker/mocks.go
+++ b/microservices/audio_processor/internal/worker/mocks.go
@@ -1,0 +1,30 @@
+package worker
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockProcessor struct {
+	mock.Mock
+}
+
+func (m *MockProcessor) ProcessRequest(ctx context.Context, req *model.MediaRequest) error {
+	args := m.Called(ctx, req)
+	return args.Error(0)
+}
+
+type MockConsumer struct {
+	mock.Mock
+}
+
+func (m *MockConsumer) GetRequestsChannel(ctx context.Context) (<-chan *model.MediaRequest, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(<-chan *model.MediaRequest), args.Error(1)
+}
+
+func (m *MockConsumer) Close() error {
+	m.Called()
+	return nil
+}

--- a/microservices/audio_processor/internal/worker/pool_test.go
+++ b/microservices/audio_processor/internal/worker/pool_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package worker
 
 import (

--- a/microservices/audio_processor/internal/worker/pool_test.go
+++ b/microservices/audio_processor/internal/worker/pool_test.go
@@ -1,0 +1,76 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+func TestWorkerPool_Start_Success(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	mockLogger := new(logger.MockLogger)
+	mockConsumer := new(MockConsumer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	requestChan := make(chan *model.MediaRequest)
+
+	numWorkers := 2
+
+	mockConsumer.On("GetRequestsChannel", ctx).Return((<-chan *model.MediaRequest)(requestChan), nil)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+
+	workerPool := NewWorkerPool(numWorkers, mockConsumer, mockProcessor, mockLogger)
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	err := workerPool.Start(ctx)
+
+	assert.NoError(t, err)
+	mockConsumer.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+	assert.Len(t, workerPool.workers, numWorkers)
+}
+
+func TestWorkerPool_Start_GetRequestsChannelError(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	mockLogger := new(logger.MockLogger)
+	mockConsumer := new(MockConsumer)
+
+	ctx := context.Background()
+	expectedError := errors.New("error al obtener canal de solicitudes")
+
+	mockConsumer.On("GetRequestsChannel", ctx).Return((<-chan *model.MediaRequest)(nil), expectedError)
+
+	workerPool := NewWorkerPool(2, mockConsumer, mockProcessor, mockLogger)
+
+	err := workerPool.Start(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error al obtener el canal de solicitudes")
+	mockConsumer.AssertExpectations(t)
+}
+
+func TestNewWorkerPool_Initialization(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	mockLogger := new(logger.MockLogger)
+	mockConsumer := new(MockConsumer)
+
+	numWorkers := 3
+
+	workerPool := NewWorkerPool(numWorkers, mockConsumer, mockProcessor, mockLogger)
+
+	assert.NotNil(t, workerPool)
+	assert.Equal(t, numWorkers, workerPool.numWorkers)
+	assert.Equal(t, mockConsumer, workerPool.consumer)
+	assert.Equal(t, mockProcessor, workerPool.processor)
+	assert.Equal(t, mockLogger, workerPool.logger)
+	assert.Len(t, workerPool.workers, numWorkers)
+}

--- a/microservices/audio_processor/internal/worker/worker_test.go
+++ b/microservices/audio_processor/internal/worker/worker_test.go
@@ -1,0 +1,101 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"github.com/stretchr/testify/mock"
+	"sync"
+	"testing"
+)
+
+func TestWorker_Start_ProcessesRequest(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	mockLogger := new(logger.MockLogger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	requestChan := make(chan *model.MediaRequest, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	worker := NewWorker(1, mockProcessor, mockLogger)
+
+	request := &model.MediaRequest{
+		RequestID: "test-request-id",
+		Song:      "https://test-url.com",
+	}
+
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockProcessor.On("ProcessRequest", ctx, request).Return(nil)
+
+	go worker.Start(ctx, &wg, requestChan)
+	requestChan <- request
+
+	close(requestChan)
+
+	wg.Wait()
+
+	mockProcessor.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestWorker_Start_HandlesProcessingError(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	mockLogger := new(logger.MockLogger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	requestChan := make(chan *model.MediaRequest, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	worker := NewWorker(1, mockProcessor, mockLogger)
+
+	request := &model.MediaRequest{
+		RequestID: "test-request-id",
+		Song:      "https://test-url.com",
+	}
+
+	expectedError := errors.New("error procesando solicitud")
+
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+	mockProcessor.On("ProcessRequest", ctx, request).Return(expectedError)
+
+	go worker.Start(ctx, &wg, requestChan)
+	requestChan <- request
+
+	close(requestChan)
+
+	wg.Wait()
+
+	mockProcessor.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestWorker_Start_HandlesContextCancellation(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	mockLogger := new(logger.MockLogger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	requestChan := make(chan *model.MediaRequest)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	worker := NewWorker(1, mockProcessor, mockLogger)
+
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+
+	go worker.Start(ctx, &wg, requestChan)
+
+	cancel()
+
+	wg.Wait()
+
+	mockLogger.AssertExpectations(t)
+}

--- a/microservices/audio_processor/internal/worker/worker_test.go
+++ b/microservices/audio_processor/internal/worker/worker_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package worker
 
 import (


### PR DESCRIPTION
- **Refactor audio processing components to use mock implementations:** This allows for easier unit testing of services that depend on audio processing, improving testability and isolation.
- **Corrected the spelling of "FFmpeg" and renamed encode session type:** This addresses a minor typo and improves code clarity by providing a more descriptive and accurate name for the encode session type.
- **Added unit tests for worker and worker pool functionality with mock implementations:** This significantly improves the test coverage of the worker and worker pool components, ensuring their reliability and correctness.