### PR TITLE
refactor: Refactor DownloadService to use worker pool and factory

### DIFF
--- a/microservices/audio_processor/internal/delivery/queue/processor/download_service.go
+++ b/microservices/audio_processor/internal/delivery/queue/processor/download_service.go
@@ -2,38 +2,17 @@ package processor
 
 import (
 	"context"
-	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/ports"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/worker"
+	"go.uber.org/zap"
 )
 
 type DownloadService struct {
-	workerPool *worker.WorkerPool
+	workerPool worker.DownloadSongWorkerPool
 	logger     logger.Logger
 }
 
-func NewDownloadService(
-	numWorkers int,
-	consumer ports.MessageConsumer,
-	mediaRepo ports.MediaRepository,
-	videoService ports.VideoService,
-	coreService ports.CoreService,
-	logger logger.Logger,
-) *DownloadService {
-	processor := NewMediaProcessor(
-		mediaRepo,
-		videoService,
-		coreService,
-		logger,
-	)
-
-	workerPool := worker.NewWorkerPool(
-		numWorkers,
-		consumer,
-		processor,
-		logger,
-	)
-
+func NewDownloadService(workerPool worker.DownloadSongWorkerPool, logger logger.Logger) *DownloadService {
 	return &DownloadService{
 		workerPool: workerPool,
 		logger:     logger,
@@ -41,6 +20,14 @@ func NewDownloadService(
 }
 
 func (s *DownloadService) Run(ctx context.Context) error {
-	s.logger.Info("Inciando servicio de descarga")
-	return s.workerPool.Start(ctx)
+	log := s.logger.With(
+		zap.String("component", "DownloadService"),
+		zap.String("method", "Run"),
+	)
+	log.Info("Inciando servicio de descarga")
+	if err := s.workerPool.Start(ctx); err != nil {
+		log.Error("Error al iniciar el servicio de descarga", zap.Error(err))
+		return err
+	}
+	return nil
 }

--- a/microservices/audio_processor/internal/delivery/queue/processor/download_service_test.go
+++ b/microservices/audio_processor/internal/delivery/queue/processor/download_service_test.go
@@ -1,0 +1,62 @@
+//go:build !integration
+
+package processor
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestNewDownloadService(t *testing.T) {
+	mockWorkerPool := new(MockDownloadSongWorkerPool)
+	mockLogger := new(logger.MockLogger)
+
+	service := NewDownloadService(mockWorkerPool, mockLogger)
+
+	assert.NotNil(t, service)
+	assert.Equal(t, mockWorkerPool, service.workerPool)
+	assert.Equal(t, mockLogger, service.logger)
+}
+
+func TestDownloadService_Run_Success(t *testing.T) {
+	mockWorkerPool := &MockDownloadSongWorkerPool{}
+	mockLogger := new(logger.MockLogger)
+	ctx := context.Background()
+
+	service := NewDownloadService(mockWorkerPool, mockLogger)
+
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Once()
+	mockWorkerPool.On("Start", ctx).Return(nil).Once()
+
+	err := service.Run(ctx)
+
+	assert.NoError(t, err)
+	mockLogger.AssertExpectations(t)
+	mockWorkerPool.AssertExpectations(t)
+}
+
+func TestDownloadService_Run_Error(t *testing.T) {
+	mockWorkerPool := &MockDownloadSongWorkerPool{}
+	mockLogger := new(logger.MockLogger)
+	ctx := context.Background()
+	expectedErr := errors.New("worker pool error")
+
+	service := NewDownloadService(mockWorkerPool, mockLogger)
+
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Once()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Once()
+	mockWorkerPool.On("Start", ctx).Return(expectedErr).Once()
+
+	err := service.Run(ctx)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	mockLogger.AssertExpectations(t)
+	mockWorkerPool.AssertExpectations(t)
+}

--- a/microservices/audio_processor/internal/delivery/queue/processor/media_processor.go
+++ b/microservices/audio_processor/internal/delivery/queue/processor/media_processor.go
@@ -31,7 +31,7 @@ func NewMediaProcessor(
 	}
 }
 
-func (p *MediaProcessor) ProcessRequest(ctx context.Context, req *model.MediaRequest) error {
+func (p *MediaProcessor) ProcessDownloadTask(ctx context.Context, req *model.MediaRequest) error {
 	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 

--- a/microservices/audio_processor/internal/delivery/queue/processor/media_processor_test.go
+++ b/microservices/audio_processor/internal/delivery/queue/processor/media_processor_test.go
@@ -1,0 +1,226 @@
+//go:build !integration
+
+package processor
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestNewMediaProcessor(t *testing.T) {
+	mockMediaRepo := new(MockMediaRepository)
+	mockVideoService := new(MockVideoService)
+	mockCoreService := new(MockCoreService)
+	mockLogger := new(logger.MockLogger)
+
+	processor := NewMediaProcessor(
+		mockMediaRepo,
+		mockVideoService,
+		mockCoreService,
+		mockLogger,
+	)
+
+	assert.NotNil(t, processor)
+	assert.Equal(t, mockMediaRepo, processor.mediaRepo)
+	assert.Equal(t, mockVideoService, processor.videoService)
+	assert.Equal(t, mockCoreService, processor.coreService)
+	assert.Equal(t, mockLogger, processor.logger)
+}
+
+func TestMediaProcessor_ProcessRequest_Success(t *testing.T) {
+	ctx := context.Background()
+	mockMediaRepo := new(MockMediaRepository)
+	mockVideoService := new(MockVideoService)
+	mockCoreService := new(MockCoreService)
+	mockLogger := new(logger.MockLogger)
+
+	processor := NewMediaProcessor(
+		mockMediaRepo,
+		mockVideoService,
+		mockCoreService,
+		mockLogger,
+	)
+
+	mediaRequest := &model.MediaRequest{
+		RequestID:    "test-request-id",
+		UserID:       "test-user-id",
+		Song:         "test-song",
+		ProviderType: "test-provider",
+	}
+
+	mediaDetails := &model.MediaDetails{
+		ID:           "test-video-id",
+		Title:        "Test Title",
+		DurationMs:   300000,
+		URL:          "https://test-url.com",
+		ThumbnailURL: "https://test-thumbnail.com",
+		Provider:     "test-provider",
+	}
+
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+
+	mockVideoService.On("GetMediaDetails", mock.Anything, mediaRequest.Song, mediaRequest.ProviderType).Return(mediaDetails, nil)
+
+	mockMediaRepo.On("SaveMedia", mock.Anything, mock.MatchedBy(func(media *model.Media) bool {
+		return media.VideoID == mediaDetails.ID && media.Metadata.Title == mediaDetails.Title
+	})).Return(nil)
+
+	mockCoreService.On("ProcessMedia", mock.Anything, mock.MatchedBy(func(media *model.Media) bool {
+		return media.VideoID == mediaDetails.ID
+	}), mediaRequest.UserID, mediaRequest.RequestID).Return(nil)
+
+	err := processor.ProcessDownloadTask(ctx, mediaRequest)
+
+	assert.NoError(t, err)
+	mockMediaRepo.AssertExpectations(t)
+	mockVideoService.AssertExpectations(t)
+	mockCoreService.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestMediaProcessor_ProcessRequest_GetMediaDetailsError(t *testing.T) {
+	ctx := context.Background()
+	mockMediaRepo := new(MockMediaRepository)
+	mockVideoService := new(MockVideoService)
+	mockCoreService := new(MockCoreService)
+	mockLogger := new(logger.MockLogger)
+
+	processor := NewMediaProcessor(
+		mockMediaRepo,
+		mockVideoService,
+		mockCoreService,
+		mockLogger,
+	)
+
+	mediaRequest := &model.MediaRequest{
+		RequestID:    "test-request-id",
+		UserID:       "test-user-id",
+		Song:         "test-song",
+		ProviderType: "test-provider",
+	}
+
+	expectedError := errors.New("error obteniendo detalles")
+
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockVideoService.On("GetMediaDetails", mock.Anything, mediaRequest.Song, mediaRequest.ProviderType).Return(&model.MediaDetails{}, expectedError)
+
+	err := processor.ProcessDownloadTask(ctx, mediaRequest)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockVideoService.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestMediaProcessor_ProcessRequest_SaveMediaError(t *testing.T) {
+	ctx := context.Background()
+	mockMediaRepo := new(MockMediaRepository)
+	mockVideoService := new(MockVideoService)
+	mockCoreService := new(MockCoreService)
+	mockLogger := new(logger.MockLogger)
+
+	processor := NewMediaProcessor(
+		mockMediaRepo,
+		mockVideoService,
+		mockCoreService,
+		mockLogger,
+	)
+
+	mediaRequest := &model.MediaRequest{
+		RequestID:    "test-request-id",
+		UserID:       "test-user-id",
+		Song:         "test-song",
+		ProviderType: "test-provider",
+	}
+
+	mediaDetails := &model.MediaDetails{
+		ID:           "test-video-id",
+		Title:        "Test Title",
+		DurationMs:   300000,
+		URL:          "https://test-url.com",
+		ThumbnailURL: "https://test-thumbnail.com",
+		Provider:     "test-provider",
+	}
+
+	expectedError := errors.New("error guardando media")
+
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockVideoService.On("GetMediaDetails", mock.Anything, mediaRequest.Song, mediaRequest.ProviderType).Return(mediaDetails, nil)
+
+	mockMediaRepo.On("SaveMedia", mock.Anything, mock.MatchedBy(func(media *model.Media) bool {
+		return media.VideoID == mediaDetails.ID && media.Metadata.Title == mediaDetails.Title
+	})).Return(expectedError)
+
+	err := processor.ProcessDownloadTask(ctx, mediaRequest)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockVideoService.AssertExpectations(t)
+	mockMediaRepo.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestMediaProcessor_ProcessRequest_ProcessMediaError(t *testing.T) {
+	ctx := context.Background()
+	mockMediaRepo := new(MockMediaRepository)
+	mockVideoService := new(MockVideoService)
+	mockCoreService := new(MockCoreService)
+	mockLogger := new(logger.MockLogger)
+
+	processor := NewMediaProcessor(
+		mockMediaRepo,
+		mockVideoService,
+		mockCoreService,
+		mockLogger,
+	)
+
+	mediaRequest := &model.MediaRequest{
+		RequestID:    "test-request-id",
+		UserID:       "test-user-id",
+		Song:         "test-song",
+		ProviderType: "test-provider",
+	}
+
+	mediaDetails := &model.MediaDetails{
+		ID:           "test-video-id",
+		Title:        "Test Title",
+		DurationMs:   300000,
+		URL:          "https://test-url.com",
+		ThumbnailURL: "https://test-thumbnail.com",
+		Provider:     "test-provider",
+	}
+
+	expectedError := errors.New("error procesando media")
+
+	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockVideoService.On("GetMediaDetails", mock.Anything, mediaRequest.Song, mediaRequest.ProviderType).Return(mediaDetails, nil)
+
+	mockMediaRepo.On("SaveMedia", mock.Anything, mock.MatchedBy(func(media *model.Media) bool {
+		return media.VideoID == mediaDetails.ID && media.Metadata.Title == mediaDetails.Title
+	})).Return(nil)
+
+	mockCoreService.On("ProcessMedia", mock.Anything, mock.MatchedBy(func(media *model.Media) bool {
+		return media.VideoID == mediaDetails.ID
+	}), mediaRequest.UserID, mediaRequest.RequestID).Return(expectedError)
+
+	err := processor.ProcessDownloadTask(ctx, mediaRequest)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockVideoService.AssertExpectations(t)
+	mockMediaRepo.AssertExpectations(t)
+	mockCoreService.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}

--- a/microservices/audio_processor/internal/delivery/queue/processor/mocks.go
+++ b/microservices/audio_processor/internal/delivery/queue/processor/mocks.go
@@ -1,0 +1,77 @@
+package processor
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockConsumer struct {
+	mock.Mock
+}
+
+func (m *MockConsumer) GetRequestsChannel(ctx context.Context) (<-chan *model.MediaRequest, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(<-chan *model.MediaRequest), args.Error(1)
+}
+
+func (m *MockConsumer) Close() error {
+	m.Called()
+	return nil
+}
+
+type MockMediaRepository struct {
+	mock.Mock
+}
+
+func (m *MockMediaRepository) SaveMedia(ctx context.Context, media *model.Media) error {
+	args := m.Called(ctx, media)
+	return args.Error(0)
+}
+
+func (m *MockMediaRepository) GetMediaByID(ctx context.Context, videoID string) (*model.Media, error) {
+	args := m.Called(ctx, videoID)
+	return args.Get(0).(*model.Media), args.Error(1)
+}
+
+func (m *MockMediaRepository) GetMediaByTitle(ctx context.Context, title string) ([]*model.Media, error) {
+	args := m.Called(ctx, title)
+	return args.Get(0).([]*model.Media), args.Error(1)
+}
+
+func (m *MockMediaRepository) DeleteMedia(ctx context.Context, videoID string) error {
+	args := m.Called(ctx, videoID)
+	return args.Error(0)
+}
+
+func (m *MockMediaRepository) UpdateMedia(ctx context.Context, videoID string, media *model.Media) error {
+	args := m.Called(ctx, videoID, media)
+	return args.Error(0)
+}
+
+type MockVideoService struct {
+	mock.Mock
+}
+
+func (m *MockVideoService) GetMediaDetails(ctx context.Context, input string, providerType string) (*model.MediaDetails, error) {
+	args := m.Called(ctx, input, providerType)
+	return args.Get(0).(*model.MediaDetails), args.Error(1)
+}
+
+type MockCoreService struct {
+	mock.Mock
+}
+
+func (m *MockCoreService) ProcessMedia(ctx context.Context, media *model.Media, userID, requestID string) error {
+	args := m.Called(ctx, media, userID, requestID)
+	return args.Error(0)
+}
+
+type MockDownloadSongWorkerPool struct {
+	mock.Mock
+}
+
+func (m *MockDownloadSongWorkerPool) Start(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/microservices/audio_processor/internal/worker/interfaces.go
+++ b/microservices/audio_processor/internal/worker/interfaces.go
@@ -3,8 +3,24 @@ package worker
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+	"sync"
 )
 
-type Processor interface {
-	ProcessRequest(ctx context.Context, req *model.MediaRequest) error
-}
+type (
+	AudioTaskProcessor interface {
+		ProcessDownloadTask(ctx context.Context, req *model.MediaRequest) error
+	}
+
+	TaskWorker interface {
+		Run(ctx context.Context, wg *sync.WaitGroup, taskChan <-chan *model.MediaRequest)
+	}
+
+	WorkerFactory interface {
+		NewWorker(id int, processor AudioTaskProcessor, logger logger.Logger) TaskWorker
+	}
+
+	DownloadSongWorkerPool interface {
+		Start(ctx context.Context) error
+	}
+)

--- a/microservices/audio_processor/internal/worker/mocks.go
+++ b/microservices/audio_processor/internal/worker/mocks.go
@@ -3,14 +3,16 @@ package worker
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
 	"github.com/stretchr/testify/mock"
+	"sync"
 )
 
 type MockProcessor struct {
 	mock.Mock
 }
 
-func (m *MockProcessor) ProcessRequest(ctx context.Context, req *model.MediaRequest) error {
+func (m *MockProcessor) ProcessDownloadTask(ctx context.Context, req *model.MediaRequest) error {
 	args := m.Called(ctx, req)
 	return args.Error(0)
 }
@@ -27,4 +29,22 @@ func (m *MockConsumer) GetRequestsChannel(ctx context.Context) (<-chan *model.Me
 func (m *MockConsumer) Close() error {
 	m.Called()
 	return nil
+}
+
+type MockTaskWorker struct {
+	mock.Mock
+}
+
+func (m *MockTaskWorker) Run(ctx context.Context, wg *sync.WaitGroup, taskChan <-chan *model.MediaRequest) {
+	m.Called(ctx, wg, taskChan)
+	wg.Done()
+}
+
+type MockWorkerFactory struct {
+	mock.Mock
+}
+
+func (m *MockWorkerFactory) NewWorker(id int, processor AudioTaskProcessor, logger logger.Logger) TaskWorker {
+	args := m.Called(id, processor, logger)
+	return args.Get(0).(TaskWorker)
 }

--- a/microservices/audio_processor/internal/worker/worker_factory.go
+++ b/microservices/audio_processor/internal/worker/worker_factory.go
@@ -1,0 +1,13 @@
+package worker
+
+import "github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/audio_processor/internal/logger"
+
+type workerFactory struct{}
+
+func (wf *workerFactory) NewWorker(id int, processor AudioTaskProcessor, logger logger.Logger) TaskWorker {
+	return NewDownloadTaskWorker(id, processor, logger)
+}
+
+func NewWorkerFactory() WorkerFactory {
+	return &workerFactory{}
+}


### PR DESCRIPTION
- **Refactor: Use worker pool and factory for download service tasks:** This introduces a worker pool and factory pattern to manage download tasks, improving concurrency and scalability. Technically, it replaces direct worker creation with a managed pool and abstracts worker creation logic.
- **Refactor: Simplify DownloadService and rename ProcessRequest:** Simplifies the `DownloadService` by injecting the worker pool and renames `ProcessRequest` to `ProcessDownloadTask` for clarity. This reduces the service's responsibilities and improves the code's readability.
- **Test: Implement download/media processor tests, add sample audio:** Implements unit tests for the download service and media processor, providing better code coverage and reliability. A sample audio file is also added for testing purposes.