### PR TITLE
refactor: Queue play requests & CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
             echo "Running golangci-lint in $dir"
             (cd $dir && golangci-lint run) || exit $?
           done
-          
-          
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -65,10 +63,6 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,17 +80,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_DEV_GITHUB_ACTION_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
       - name: Run integration tests
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
-          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-          DYNAMODB_TABLE_NAME_SONGS: ${{ secrets.DYNAMODB_TABLE_NAME_SONGS }}
-          DYNAMODB_TABLE_NAME_OPERATION: ${{ secrets.DYNAMODB_TABLE_NAME_OPERATION }}
-          SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
         run: make integration-test

--- a/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_aws/bot/bot.go
@@ -100,12 +100,13 @@ func StartBot() error {
 	playerFactory := discord.NewGuildPlayerFactory(discordClient, storageAudio, discordMessenger, logger)
 	guildManager := discord.NewGuildManager(playerFactory, logger)
 	eventsHandler := events.NewEventHandler(guildManager, voiceStateService, logger, cfg)
+	queueManager := service.NewPlayRequestManager(songService, guildManager, logger)
 	handler := command.NewCommandHandler(
 		interactionStorage,
 		logger,
-		songService,
 		guildManager,
 		discordMessenger,
+		queueManager,
 	)
 
 	commandRegistry := command.NewCommandRegistry()

--- a/microservices/butakero_bot/cmd/bot_local/bot/bot.go
+++ b/microservices/butakero_bot/cmd/bot_local/bot/bot.go
@@ -105,12 +105,13 @@ func StartBot() error {
 	playerFactory := discord.NewGuildPlayerFactory(discordClient, storageAudio, discordMessenger, logger)
 	guildManager := discord.NewGuildManager(playerFactory, logger)
 	eventsHandler := events.NewEventHandler(guildManager, voiceStateService, logger, cfg)
+	queueManager := service.NewPlayRequestManager(songService, guildManager, logger)
 	handler := command.NewCommandHandler(
 		interactionStorage,
 		logger,
-		songService,
 		guildManager,
 		discordMessenger,
+		queueManager,
 	)
 
 	commandRegistry := command.NewCommandRegistry()

--- a/microservices/butakero_bot/internal/application/service/play_request_service.go
+++ b/microservices/butakero_bot/internal/application/service/play_request_service.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/trace"
+	"go.uber.org/zap"
+	"sync"
+)
+
+type PlayRequestManager struct {
+	guildQueues  map[string]chan model.PlayRequestData
+	mu           sync.Mutex
+	songService  ports.SongService
+	guildManager ports.GuildManager
+	logger       logging.Logger
+}
+
+func NewPlayRequestManager(service ports.SongService, gm ports.GuildManager, logger logging.Logger) *PlayRequestManager {
+	return &PlayRequestManager{
+		guildQueues:  make(map[string]chan model.PlayRequestData),
+		songService:  service,
+		guildManager: gm,
+		logger:       logger,
+	}
+}
+
+func (prm *PlayRequestManager) Enqueue(guildID string, data model.PlayRequestData) <-chan model.PlayResult {
+	resultChan := make(chan model.PlayResult, 1)
+
+	prm.mu.Lock()
+	queue, exists := prm.guildQueues[guildID]
+	if !exists {
+		queue = make(chan model.PlayRequestData, 100)
+		prm.guildQueues[guildID] = queue
+		go prm.guildWorker(guildID, queue, resultChan)
+	}
+	prm.mu.Unlock()
+
+	queue <- data
+	return resultChan
+}
+
+func (prm *PlayRequestManager) guildWorker(guildID string, queue chan model.PlayRequestData, resultChan chan<- model.PlayResult) {
+	defer close(resultChan)
+
+	for request := range queue {
+		workerCtx := trace.WithTraceID(request.Ctx)
+		_ = prm.logger.With(zap.String("guildID", guildID))
+
+		songEntity, err := prm.songService.GetOrDownloadSong(workerCtx, request.UserID, request.SongInput, "youtube")
+		if err != nil {
+			resultChan <- model.PlayResult{
+				Err:             fmt.Errorf("no se pudo obtener/descargar la canción: %w", err),
+				RequestedByID:   request.UserID,
+				RequestedByName: request.RequestedByName,
+			}
+			continue
+		}
+
+		guildPlayer, err := prm.guildManager.GetGuildPlayer(request.GuildID)
+		if err != nil {
+			resultChan <- model.PlayResult{
+				Err:             fmt.Errorf("error al obtener GuildPlayer: %w", err),
+				RequestedByID:   request.UserID,
+				RequestedByName: request.RequestedByName,
+			}
+			continue
+		}
+
+		playedSong := &entity.PlayedSong{
+			DiscordSong:     songEntity,
+			RequestedByName: request.RequestedByName,
+			RequestedByID:   request.UserID,
+		}
+
+		if err := guildPlayer.AddSong(workerCtx, &request.ChannelID, &request.VoiceChannelID, playedSong); err != nil {
+			resultChan <- model.PlayResult{
+				SongTitle:       songEntity.TitleTrack,
+				Err:             fmt.Errorf("no se pudo agregar la canción '%s' a la cola: %w", songEntity.TitleTrack, err),
+				RequestedByID:   request.UserID,
+				RequestedByName: request.RequestedByName,
+			}
+			continue
+		}
+
+		resultChan <- model.PlayResult{
+			SongTitle:       songEntity.TitleTrack,
+			RequestedByID:   request.UserID,
+			RequestedByName: request.RequestedByName,
+		}
+	}
+}

--- a/microservices/butakero_bot/internal/domain/model/play_request.go
+++ b/microservices/butakero_bot/internal/domain/model/play_request.go
@@ -1,0 +1,14 @@
+package model
+
+import "context"
+
+type PlayRequestData struct {
+	Ctx             context.Context
+	GuildID         string
+	ChannelID       string
+	VoiceChannelID  string
+	UserID          string
+	SongInput       string
+	OriginalMsgID   string
+	RequestedByName string
+}

--- a/microservices/butakero_bot/internal/domain/model/play_result.go
+++ b/microservices/butakero_bot/internal/domain/model/play_result.go
@@ -1,0 +1,8 @@
+package model
+
+type PlayResult struct {
+	SongTitle       string
+	Err             error
+	RequestedByID   string
+	RequestedByName string
+}

--- a/microservices/butakero_bot/internal/domain/ports/service_ports.go
+++ b/microservices/butakero_bot/internal/domain/ports/service_ports.go
@@ -3,10 +3,17 @@ package ports
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
 )
 
 // SongService es la interfaz que define los métodos para manejar canciones
-type SongService interface {
-	// GetOrDownloadSong inicia el proceso de descarga de una canción al otro servicio mediante colas
-	GetOrDownloadSong(ctx context.Context, userID, songInput, providerType string) (*entity.DiscordEntity, error)
-}
+type (
+	SongService interface {
+		// GetOrDownloadSong inicia el proceso de descarga de una canción al otro servicio mediante colas
+		GetOrDownloadSong(ctx context.Context, userID, songInput, providerType string) (*entity.DiscordEntity, error)
+	}
+
+	PlayRequestService interface {
+		Enqueue(guildID string, data model.PlayRequestData) <-chan model.PlayResult
+	}
+)

--- a/microservices/butakero_bot/internal/infrastructure/discord/guild_manager.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/guild_manager.go
@@ -58,7 +58,6 @@ func (f *GuildPlayerFactory) CreatePlayer(guildID string) (ports.GuildPlayer, er
 			SongStorage:     songStorage,
 			StateStorage:    stateStorage,
 			Messenger:       f.messenger,
-			StorageAudio:    f.storageAudio,
 			Logger:          f.logger,
 		},
 	)

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/controller_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/controller_test.go
@@ -1,4 +1,4 @@
-//go:build !integration
+////go:build !integration
 
 package player
 

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/mocks.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/mocks.go
@@ -12,6 +12,11 @@ type MockVoiceSession struct {
 	mock.Mock
 }
 
+func (m *MockVoiceSession) IsConnected() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 func (m *MockVoiceSession) JoinVoiceChannel(ctx context.Context, channelID string) error {
 	args := m.Called(ctx, channelID)
 	return args.Error(0)


### PR DESCRIPTION
- **Introduced a Play Request Queue:** This change creates a queue for handling song play requests per guild. This prevents race conditions and ensures songs are added to the player in the order they are requested. It uses a `PlayRequestManager` with a worker goroutine per guild to process the queue.
  - Purpose: Improves the robustness of the bot by ensuring song requests are handled sequentially.
  - Technical Impact: Adds new files related to the `PlayRequestManager` and modifies existing command handlers to use the queue. It involves changes in the bot's architecture to handle concurrent play requests efficiently.

- **Enhanced Voice Session Robustness:** This refactor adds retries, timeout handling, and reconnection logic to voice sessions, making them more resilient to network issues. Implements proper locking when joining voice channels and sending audio.
  - Purpose: Improves the reliability of voice playback by handling potential errors and reconnections gracefully.  This makes the bot more reliable under less than ideal network conditions.
  - Technical Impact:  The `DiscordVoiceSession` is significantly refactored to include retry logic, error handling, and improved state management.

- **CI Configuration Cleanup:** Removes unused permissions and steps from the CI workflow file (`.github/workflows/ci.yml`).
  - Purpose: Simplifies the CI configuration and reduces unnecessary overhead. This makes the CI pipeline cleaner and potentially faster.
  - Technical Impact: Removes `permissions` for `id-token`, `contents`, and `pull-requests` from the `integration-tests` job, and removes AWS credential configuration steps.