### PR TITLE
refactor: Simplify audio handling & improve decoder usage

### DIFF
--- a/microservices/butakero_bot/internal/domain/ports/audio_ports.go
+++ b/microservices/butakero_bot/internal/domain/ports/audio_ports.go
@@ -5,18 +5,8 @@ import (
 	"io"
 )
 
-type (
-	// Decoder define una interfaz para decodificar audio descargado a un formato que Discord entiende.
-	Decoder interface {
-		// OpusFrame devuelve un marco de audio en formato Opus.
-		OpusFrame() ([]byte, error)
-		// Close cierra el decodificador.
-		Close() error
-	}
-
-	// StorageAudio define métodos para obtener el contenido de archivos de audio.
-	StorageAudio interface {
-		// GetAudio obtiene el contenido del archivo de audio
-		GetAudio(ctx context.Context, songPath string) (io.ReadCloser, error)
-	}
-)
+// StorageAudio define métodos para obtener el contenido de archivos de audio.
+type StorageAudio interface {
+	// GetAudio obtiene el contenido del archivo de audio
+	GetAudio(ctx context.Context, songPath string) (io.ReadCloser, error)
+}

--- a/microservices/butakero_bot/internal/infrastructure/decoder/opus_decoder.go
+++ b/microservices/butakero_bot/internal/infrastructure/decoder/opus_decoder.go
@@ -5,8 +5,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/interfaces"
 	"io"
 )
+
+var _ interfaces.Decoder = (*OpusDecoder)(nil)
 
 var (
 	ErrNotFirstFrame     = errors.New("la metadata solo puede encontrarse en el primer marco")

--- a/microservices/butakero_bot/internal/infrastructure/discord/interfaces/decoder.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/interfaces/decoder.go
@@ -1,0 +1,9 @@
+package interfaces
+
+// Decoder define una interfaz para decodificar audio descargado a un formato que Discord entiende.
+type Decoder interface {
+	// OpusFrame devuelve un marco de audio en formato Opus.
+	OpusFrame() ([]byte, error)
+	// Close cierra el decodificador.
+	Close() error
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/interfaces/voice_session.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/interfaces/voice_session.go
@@ -2,7 +2,6 @@ package interfaces
 
 import (
 	"context"
-	"io"
 )
 
 // VoiceConnection define una interfaz para manejar sesiones de voz.
@@ -12,7 +11,7 @@ type VoiceConnection interface {
 	// LeaveVoiceChannel deja el canal de voz actual.
 	LeaveVoiceChannel(ctx context.Context) error
 	// SendAudio envía audio a través de la sesión de voz.
-	SendAudio(ctx context.Context, reader io.ReadCloser) error
+	SendAudio(ctx context.Context, audioDecoder Decoder) error
 	// Pause pausa la sesión de voz.
 	Pause()
 	// Resume reanuda la sesión de voz.

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/controller_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/controller_test.go
@@ -256,6 +256,7 @@ func TestPlaybackController_Play(t *testing.T) {
 		logger.On("Debug", mock.Anything, mock.Anything, mock.Anything).Return(logger)
 		logger.On("Error", mock.Anything, mock.Anything, mock.Anything).Return(logger)
 		mockStateStorage.On("SetCurrentTrack", mock.Anything, song).Return(nil).Once()
+		mockStateStorage.On("SetCurrentTrack", mock.Anything, (*entity.PlayedSong)(nil)).Return(nil).Once()
 		mockMessenger.On("SendPlayStatus", "text-channel", song).Return("", errors.New("send error")).Once()
 		mockStorageAudio.On("GetAudio", mock.Anything, "test.mp3").Return(nil, errors.New("audio error")).Once()
 

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/mocks.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/mocks.go
@@ -3,6 +3,7 @@ package player
 import (
 	"context"
 	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/infrastructure/discord/interfaces"
 	"github.com/bwmarrin/discordgo"
 	"github.com/stretchr/testify/mock"
 	"io"
@@ -27,8 +28,8 @@ func (m *MockVoiceSession) LeaveVoiceChannel(ctx context.Context) error {
 	return args.Error(0)
 }
 
-func (m *MockVoiceSession) SendAudio(ctx context.Context, reader io.ReadCloser) error {
-	args := m.Called(ctx, reader)
+func (m *MockVoiceSession) SendAudio(ctx context.Context, audioDecoder interfaces.Decoder) error {
+	args := m.Called(ctx, audioDecoder)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
- **Consolidated audio decoder interfaces:** Moved the `Decoder` interface to `internal/infrastructure/discord/interfaces/decoder.go` and removed the duplicate definition from `internal/domain/ports/audio_ports.go`. This promotes code reuse and avoids ambiguity.
- **Updated `VoiceConnection` interface:** Modified the `SendAudio` method in the `VoiceConnection` interface to accept a `Decoder` interface instead of an `io.ReadCloser`. This provides more flexibility and encapsulates the audio decoding logic.
- **Improved audio streaming:** Refactored `streamAudio` in `PlaybackController` to use `decoder.NewBufferedOpusDecoder` directly and handle potential errors during decoding, like a closed decoder.

**Purpose:**  These changes aim to streamline the audio processing pipeline, improve code maintainability, and enhance error handling during audio playback.

**Technical Impact:** The `SendAudio` interface change requires adaptation in implementations and mocks. The new decoder implementation handles potential errors ensuring a more robust audio playing experience.