### PR TITLE
refactor: Improve play request handling and add bot move feature

### DIFF
--- a/microservices/butakero_bot/internal/application/service/mocks.go
+++ b/microservices/butakero_bot/internal/application/service/mocks.go
@@ -1,4 +1,4 @@
-package discord
+package service
 
 import (
 	"context"
@@ -7,11 +7,33 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type MockPlayerFactory struct {
+type MockSongService struct {
 	mock.Mock
 }
 
-func (m *MockPlayerFactory) CreatePlayer(guildID string) (ports.GuildPlayer, error) {
+func (m *MockSongService) GetOrDownloadSong(ctx context.Context, userID, songInput, platform string) (*entity.DiscordEntity, error) {
+	args := m.Called(ctx, userID, songInput, platform)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entity.DiscordEntity), args.Error(1)
+}
+
+type MockGuildManager struct {
+	mock.Mock
+}
+
+func (m *MockGuildManager) CreateGuildPlayer(guildID string) (ports.GuildPlayer, error) {
+	args := m.Called(guildID)
+	return args.Get(0).(ports.GuildPlayer), args.Error(1)
+}
+
+func (m *MockGuildManager) RemoveGuildPlayer(guildID string) error {
+	args := m.Called(guildID)
+	return args.Error(0)
+}
+
+func (m *MockGuildManager) GetGuildPlayer(guildID string) (ports.GuildPlayer, error) {
 	args := m.Called(guildID)
 	return args.Get(0).(ports.GuildPlayer), args.Error(1)
 }

--- a/microservices/butakero_bot/internal/application/service/play_request_service_test.go
+++ b/microservices/butakero_bot/internal/application/service/play_request_service_test.go
@@ -1,0 +1,350 @@
+//go:build !integration
+
+package service
+
+import (
+	"context"
+	"errors"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+func TestEnqueue_Success(t *testing.T) {
+	// arrange
+	mockSongService := new(MockSongService)
+	mockGuildManager := new(MockGuildManager)
+	mockLogger := new(logging.MockLogger)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	prm := NewPlayRequestManager(mockSongService, mockGuildManager, mockLogger)
+
+	ctx := context.Background()
+	guildID := "123456789"
+	userID := "987654321"
+	songInput := "test song"
+	channelID := "channel123"
+	voiceChannelID := "voice123"
+	requestedByName := "Test User"
+
+	discordSong := &entity.DiscordEntity{
+		TitleTrack: "Test Song Title",
+		DurationMs: 3600000,
+		URL:        "https://example.com/test",
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockSongService.On("GetOrDownloadSong", mock.Anything, userID, songInput, "youtube").Return(discordSong, nil)
+	mockGuildManager.On("GetGuildPlayer", guildID).Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("AddSong", mock.Anything, &channelID, &voiceChannelID, mock.MatchedBy(func(s *entity.PlayedSong) bool {
+		return s.RequestedByID == userID && s.RequestedByName == requestedByName && s.DiscordSong.TitleTrack == discordSong.TitleTrack
+	})).Return(nil)
+
+	requestData := model.PlayRequestData{
+		Ctx:             ctx,
+		GuildID:         guildID,
+		UserID:          userID,
+		ChannelID:       channelID,
+		VoiceChannelID:  voiceChannelID,
+		SongInput:       songInput,
+		RequestedByName: requestedByName,
+	}
+
+	// act
+	resultChan := prm.Enqueue(guildID, requestData)
+
+	// assert
+	result := <-resultChan
+	assert.NoError(t, result.Err)
+	assert.Equal(t, discordSong.TitleTrack, result.SongTitle)
+	assert.Equal(t, userID, result.RequestedByID)
+	assert.Equal(t, requestedByName, result.RequestedByName)
+
+	mockSongService.AssertExpectations(t)
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+}
+
+func TestEnqueue_SongServiceError(t *testing.T) {
+	// arrange
+	mockSongService := new(MockSongService)
+	mockGuildManager := new(MockGuildManager)
+	mockLogger := new(logging.MockLogger)
+
+	prm := NewPlayRequestManager(mockSongService, mockGuildManager, mockLogger)
+
+	ctx := context.Background()
+	guildID := "123456789"
+	userID := "987654321"
+	songInput := "test song"
+	channelID := "channel123"
+	voiceChannelID := "voice123"
+	requestedByName := "Test User"
+	expectedError := errors.New("song download failed")
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockSongService.On("GetOrDownloadSong", mock.Anything, userID, songInput, "youtube").Return(nil, expectedError)
+
+	requestData := model.PlayRequestData{
+		Ctx:             ctx,
+		GuildID:         guildID,
+		UserID:          userID,
+		ChannelID:       channelID,
+		VoiceChannelID:  voiceChannelID,
+		SongInput:       songInput,
+		RequestedByName: requestedByName,
+	}
+
+	// act
+	resultChan := prm.Enqueue(guildID, requestData)
+
+	// assert
+	result := <-resultChan
+	assert.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "no se pudo obtener/descargar la canción")
+	assert.Equal(t, userID, result.RequestedByID)
+	assert.Equal(t, requestedByName, result.RequestedByName)
+
+	mockSongService.AssertExpectations(t)
+}
+
+func TestEnqueue_GuildManagerError(t *testing.T) {
+	// arrange
+	mockSongService := new(MockSongService)
+	mockGuildManager := new(MockGuildManager)
+	mockLogger := new(logging.MockLogger)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	prm := NewPlayRequestManager(mockSongService, mockGuildManager, mockLogger)
+
+	ctx := context.Background()
+	guildID := "123456789"
+	userID := "987654321"
+	songInput := "test song"
+	channelID := "channel123"
+	voiceChannelID := "voice123"
+	requestedByName := "Test User"
+	expectedError := errors.New("guild player not found")
+
+	discordSong := &entity.DiscordEntity{
+		TitleTrack: "Test Song Title",
+		DurationMs: 3600000,
+		URL:        "https://example.com/test",
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockSongService.On("GetOrDownloadSong", mock.Anything, userID, songInput, "youtube").Return(discordSong, nil)
+	mockGuildManager.On("GetGuildPlayer", guildID).Return(mockGuildPlayer, expectedError)
+
+	requestData := model.PlayRequestData{
+		Ctx:             ctx,
+		GuildID:         guildID,
+		UserID:          userID,
+		ChannelID:       channelID,
+		VoiceChannelID:  voiceChannelID,
+		SongInput:       songInput,
+		RequestedByName: requestedByName,
+	}
+
+	// act
+	resultChan := prm.Enqueue(guildID, requestData)
+
+	// assert
+	result := <-resultChan
+	assert.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "error al obtener GuildPlayer")
+	assert.Equal(t, userID, result.RequestedByID)
+	assert.Equal(t, requestedByName, result.RequestedByName)
+
+	mockSongService.AssertExpectations(t)
+	mockGuildManager.AssertExpectations(t)
+}
+
+func TestEnqueue_AddSongError(t *testing.T) {
+	// arrange
+	mockSongService := new(MockSongService)
+	mockGuildManager := new(MockGuildManager)
+	mockLogger := new(logging.MockLogger)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	prm := NewPlayRequestManager(mockSongService, mockGuildManager, mockLogger)
+
+	ctx := context.Background()
+	guildID := "123456789"
+	userID := "987654321"
+	songInput := "test song"
+	channelID := "channel123"
+	voiceChannelID := "voice123"
+	requestedByName := "Test User"
+	expectedError := errors.New("could not add song to queue")
+
+	discordSong := &entity.DiscordEntity{
+		TitleTrack: "Test Song Title",
+		DurationMs: 36000000,
+		URL:        "https://example.com/test",
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	mockSongService.On("GetOrDownloadSong", mock.Anything, userID, songInput, "youtube").Return(discordSong, nil)
+	mockGuildManager.On("GetGuildPlayer", guildID).Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("AddSong", mock.Anything, &channelID, &voiceChannelID, mock.MatchedBy(func(s *entity.PlayedSong) bool {
+		return s.RequestedByID == userID && s.RequestedByName == requestedByName && s.DiscordSong.TitleTrack == discordSong.TitleTrack
+	})).Return(expectedError)
+
+	requestData := model.PlayRequestData{
+		Ctx:             ctx,
+		GuildID:         guildID,
+		UserID:          userID,
+		ChannelID:       channelID,
+		VoiceChannelID:  voiceChannelID,
+		SongInput:       songInput,
+		RequestedByName: requestedByName,
+	}
+
+	// act
+	resultChan := prm.Enqueue(guildID, requestData)
+
+	// assert
+	result := <-resultChan
+	assert.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "no se pudo agregar la canción")
+	assert.Equal(t, discordSong.TitleTrack, result.SongTitle)
+	assert.Equal(t, userID, result.RequestedByID)
+	assert.Equal(t, requestedByName, result.RequestedByName)
+
+	mockSongService.AssertExpectations(t)
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+}
+
+func TestNewPlayRequestManager(t *testing.T) {
+	// arrange
+	mockSongService := new(MockSongService)
+	mockGuildManager := new(MockGuildManager)
+	mockLogger := new(logging.MockLogger)
+
+	// act
+	prm := NewPlayRequestManager(mockSongService, mockGuildManager, mockLogger)
+
+	// assert
+	assert.NotNil(t, prm)
+	assert.NotNil(t, prm.guildQueues)
+	assert.Equal(t, mockSongService, prm.songService)
+	assert.Equal(t, mockGuildManager, prm.guildManager)
+	assert.Equal(t, mockLogger, prm.logger)
+}
+
+func TestMultipleEnqueueRequests(t *testing.T) {
+	// arrange
+	mockSongService := new(MockSongService)
+	mockGuildManager := new(MockGuildManager)
+	mockLogger := new(logging.MockLogger)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	prm := NewPlayRequestManager(mockSongService, mockGuildManager, mockLogger)
+
+	ctx := context.Background()
+	guildID := "123456789"
+	userID := "987654321"
+	channelID := "channel123"
+	voiceChannelID := "voice123"
+	requestedByName := "Test User"
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	song1Input := "first song"
+	song1 := &entity.DiscordEntity{
+		TitleTrack: "First Song Title",
+		DurationMs: 3600000,
+		URL:        "https://example.com/first",
+	}
+
+	mockSongService.On("GetOrDownloadSong", mock.Anything, userID, song1Input, "youtube").Return(song1, nil)
+	mockGuildManager.On("GetGuildPlayer", guildID).Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("AddSong", mock.Anything, &channelID, &voiceChannelID, mock.MatchedBy(func(s *entity.PlayedSong) bool {
+		return s.DiscordSong.TitleTrack == song1.TitleTrack
+	})).Return(nil)
+
+	song2Input := "second song"
+	song2 := &entity.DiscordEntity{
+		TitleTrack: "Second Song Title",
+		DurationMs: 4800000,
+		URL:        "https://example.com/second",
+	}
+
+	mockSongService.On("GetOrDownloadSong", mock.Anything, userID, song2Input, "youtube").Return(song2, nil)
+	mockGuildPlayer.On("AddSong", mock.Anything, &channelID, &voiceChannelID, mock.MatchedBy(func(s *entity.PlayedSong) bool {
+		return s.DiscordSong.TitleTrack == song2.TitleTrack
+	})).Return(nil)
+
+	request1 := model.PlayRequestData{
+		Ctx:             ctx,
+		GuildID:         guildID,
+		UserID:          userID,
+		ChannelID:       channelID,
+		VoiceChannelID:  voiceChannelID,
+		SongInput:       song1Input,
+		RequestedByName: requestedByName,
+	}
+
+	request2 := model.PlayRequestData{
+		Ctx:             ctx,
+		GuildID:         guildID,
+		UserID:          userID,
+		ChannelID:       channelID,
+		VoiceChannelID:  voiceChannelID,
+		SongInput:       song2Input,
+		RequestedByName: requestedByName,
+	}
+
+	// act
+	resultChan1 := prm.Enqueue(guildID, request1)
+	resultChan2 := prm.Enqueue(guildID, request2)
+
+	// assert
+	var result1, result2 model.PlayResult
+
+	select {
+	case result1 = <-resultChan1:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for first result")
+	}
+
+	select {
+	case result2 = <-resultChan2:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for second result")
+	}
+
+	assert.NoError(t, result1.Err)
+	assert.Equal(t, song1.TitleTrack, result1.SongTitle)
+	assert.Equal(t, userID, result1.RequestedByID)
+	assert.Equal(t, requestedByName, result1.RequestedByName)
+
+	assert.NoError(t, result2.Err)
+	assert.Equal(t, song2.TitleTrack, result2.SongTitle)
+	assert.Equal(t, userID, result2.RequestedByID)
+	assert.Equal(t, requestedByName, result2.RequestedByName)
+
+	mockSongService.AssertExpectations(t)
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+}

--- a/microservices/butakero_bot/internal/domain/model/play_request.go
+++ b/microservices/butakero_bot/internal/domain/model/play_request.go
@@ -11,4 +11,5 @@ type PlayRequestData struct {
 	SongInput       string
 	OriginalMsgID   string
 	RequestedByName string
+	ResultChan      chan PlayResult
 }

--- a/microservices/butakero_bot/internal/domain/ports/discord_ports.go
+++ b/microservices/butakero_bot/internal/domain/ports/discord_ports.go
@@ -32,14 +32,11 @@ type (
 		// GetPlayedSong obtiene la información de la canción que se está reproduciendo
 		GetPlayedSong(ctx context.Context) (*entity.PlayedSong, error)
 
-		// StateStorage retorna el almacenamiento de estado del reproductor
-		StateStorage() PlayerStateStorage
-
-		// JoinVoiceChannel conecta el bot a un canal de voz específico
-		JoinVoiceChannel(ctx context.Context, channelID string) error
-
 		// Close libera los recursos asociados al reproductor
 		Close() error
+
+		// MoveToVoiceChannel mueve el bot a un nuevo canal de voz
+		MoveToVoiceChannel(ctx context.Context, newChannelID string) error
 	}
 
 	// GuildManager maneja los reproductores de música para diferentes servidores

--- a/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/commands.go
@@ -47,7 +47,7 @@ func (h *CommandHandler) PlaySong(s *discordgo.Session, ic *discordgo.Interactio
 	ctx := trace.WithTraceID(context.Background())
 	logger := h.logger.With(zap.String("guildID", ic.GuildID))
 
-	vs, ok := h.isUserInVoiceChannel(s, ic)
+	vs, ok := h.isUserInVoiceChannel(ctx, s, ic)
 	if !ok {
 		return
 	}
@@ -439,9 +439,7 @@ func (h *CommandHandler) respondWithError(ic *discordgo.InteractionCreate, messa
 	}
 }
 
-func (h *CommandHandler) isUserInVoiceChannel(s *discordgo.Session, ic *discordgo.InteractionCreate) (*discordgo.VoiceState, bool) {
-	ctx := trace.WithTraceID(context.Background())
-
+func (h *CommandHandler) isUserInVoiceChannel(ctx context.Context, s *discordgo.Session, ic *discordgo.InteractionCreate) (*discordgo.VoiceState, bool) {
 	logger := h.logger.With(
 		zap.String("component", "CommandHandler"),
 		zap.String("method", "isUserInVoiceChannel"),


### PR DESCRIPTION
- **Refactor Play Request Handling:** Modifies the `PlayRequestManager` to use individual result channels for each play request, improving error handling and tracking. This enhances the reliability of song queuing.
- **Implement Bot Move Feature:** Adds the `MoveToVoiceChannel` method to the `GuildPlayer` interface and implementation, allowing the bot to move between voice channels programmatically.
- **Add Mock Implementations:** Introduce mock implementations for song service, guild manager, and guild player for isolated unit testing. This improves testability.