### PR TITLE
feat: Add mock implementations for tests and remove messenger dependency

### DIFF
--- a/microservices/butakero_bot/internal/infrastructure/discord/command/commands_test.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/commands_test.go
@@ -1,0 +1,972 @@
+//go:build !integration
+
+package command
+
+import (
+	"errors"
+	"fmt"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/errors_app"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/shared/logging"
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+func TestCommandHandler_PlaySong_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+
+	session := &discordgo.Session{State: discordgo.NewState()}
+	session.State.User = &discordgo.User{ID: "bot123"}
+
+	guild := &discordgo.Guild{
+		ID: "guild123",
+		VoiceStates: []*discordgo.VoiceState{
+			{UserID: "user123", ChannelID: "voiceChannel123"},
+		},
+	}
+	err := session.State.GuildAdd(guild)
+	if err != nil {
+		t.Fatalf("Error al añadir el estado del servidor: %v", err)
+	}
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	opt := &discordgo.ApplicationCommandInteractionDataOption{
+		Options: []*discordgo.ApplicationCommandInteractionDataOption{
+			{
+				Type:  discordgo.ApplicationCommandOptionString,
+				Name:  "song",
+				Value: "test song",
+			},
+		},
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockDiscordMessenger.On("Respond", mock.Anything, mock.Anything).Return(nil)
+	mockDiscordMessenger.On("GetOriginalResponseID", mock.Anything).Return("msg123", nil)
+	mockDiscordMessenger.On("EditMessageByID", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	resultChan := make(chan model.PlayResult, 1)
+	readOnlyChan := (<-chan model.PlayResult)(resultChan)
+
+	mockQueueManager.On("Enqueue", mock.Anything, mock.Anything).Return(readOnlyChan)
+
+	go func() {
+		resultChan <- model.PlayResult{
+			SongTitle: "Test Song Title",
+			Err:       nil,
+		}
+		close(resultChan)
+	}()
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	// Act
+	handler.PlaySong(session, interaction, opt)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Assert
+	mockLogger.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockQueueManager.AssertExpectations(t)
+
+	mockQueueManager.AssertCalled(t, "Enqueue", "guild123", mock.MatchedBy(func(data model.PlayRequestData) bool {
+		return data.GuildID == "guild123" &&
+			data.SongInput == "test song" &&
+			data.VoiceChannelID == "voiceChannel123" &&
+			data.RequestedByName == "testUser"
+	}))
+}
+
+func TestCommandHandler_StopPlaying_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("Stop", mock.Anything).Return(nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, SuccessMessagePlayingStopped).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.StopPlaying(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+}
+
+func TestCommandHandler_ListPlaylist_ErrorGettingPlaylist(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", "Error al obtener la lista de reproducción", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("GetPlaylist", mock.Anything).Return([]*entity.PlayedSong{}, errors.New("error getting playlist"))
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageGenericPlaylist).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.ListPlaylist(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_RemoveSong_InvalidPosition(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Warn", "Opción de posición para remover canción inválida o faltante", mock.Anything).Return()
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageInvalidRemovePosition).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	opt := &discordgo.ApplicationCommandInteractionDataOption{
+		Options: []*discordgo.ApplicationCommandInteractionDataOption{
+			{
+				Type:  discordgo.ApplicationCommandOptionString, // Wrong type
+				Name:  "posición",
+				Value: "invalid",
+			},
+		},
+	}
+
+	// Act
+	handler.RemoveSong(interaction, opt)
+
+	// Assert
+	mockLogger.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+}
+
+func TestCommandHandler_GetPlayingSong_ErrorGettingSong(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", "Error al obtener la canción actual", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("GetPlayedSong", mock.Anything).Return(nil, errors.New("error getting song"))
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageGenericPlaylist).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.GetPlayingSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_PauseSong_Error(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("Pause", mock.Anything).Return(errors.New("failed to pause"))
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageGenericPause).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.PauseSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_PlaySong_Error_QueueEnqueue(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+
+	session := &discordgo.Session{State: discordgo.NewState()}
+	session.State.User = &discordgo.User{ID: "bot123"}
+
+	guild := &discordgo.Guild{
+		ID: "guild123",
+		VoiceStates: []*discordgo.VoiceState{
+			{UserID: "user123", ChannelID: "voiceChannel123"},
+		},
+	}
+	err := session.State.GuildAdd(guild)
+	if err != nil {
+		t.Fatalf("Error al añadir el estado del servidor: %v", err)
+	}
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	opt := &discordgo.ApplicationCommandInteractionDataOption{
+		Options: []*discordgo.ApplicationCommandInteractionDataOption{
+			{
+				Type:  discordgo.ApplicationCommandOptionString,
+				Name:  "song",
+				Value: "test song",
+			},
+		},
+	}
+
+	resultChan := make(chan model.PlayResult, 1)
+	readOnlyChan := (<-chan model.PlayResult)(resultChan)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+	mockDiscordMessenger.On("Respond", mock.Anything, mock.Anything).Return(nil)
+	mockDiscordMessenger.On("GetOriginalResponseID", mock.Anything).Return("msg123", nil)
+	mockDiscordMessenger.On("EditMessageByID", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockQueueManager.On("Enqueue", mock.Anything, mock.Anything).Return(readOnlyChan)
+
+	go func() {
+		resultChan <- model.PlayResult{
+			SongTitle: "",
+			Err:       errors.New("error al encolar canción"),
+		}
+		close(resultChan)
+	}()
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	// Act
+	handler.PlaySong(session, interaction, opt)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Assert
+	mockQueueManager.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_PlaySong_Error_InitialResponse(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+
+	session := &discordgo.Session{State: discordgo.NewState()}
+	session.State.User = &discordgo.User{ID: "bot123"}
+
+	guild := &discordgo.Guild{
+		ID: "guild123",
+		VoiceStates: []*discordgo.VoiceState{
+			{UserID: "user123", ChannelID: "voiceChannel123"},
+		},
+	}
+	err := session.State.GuildAdd(guild)
+	if err != nil {
+		t.Fatalf("Error al añadir el estado del servidor: %v", err)
+	}
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	opt := &discordgo.ApplicationCommandInteractionDataOption{
+		Options: []*discordgo.ApplicationCommandInteractionDataOption{
+			{
+				Type:  discordgo.ApplicationCommandOptionString,
+				Name:  "song",
+				Value: "test song",
+			},
+		},
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", "Error al enviar respuesta inicial", mock.Anything).Return()
+	mockDiscordMessenger.On("Respond", mock.Anything, mock.Anything).Return(errors.New("error al responder"))
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	// Act
+	handler.PlaySong(session, interaction, opt)
+
+	// Assert
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_StopPlaying_FailedToGetPlayer(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", "Error al obtener GuildPlayer", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, errors.New("player not found"))
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageGuildPlayerNotAccesible).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.StopPlaying(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_StopPlaying_FailedToStop(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Error", "Error al detener la reproducción", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("Stop", mock.Anything).Return(errors.New("failed to stop"))
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageGenericStop).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.StopPlaying(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_SkipSong_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("SkipSong", mock.Anything).Return(nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, SuccessMessageSongSkipped).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.SkipSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+}
+
+func TestCommandHandler_SkipSong_NotPlaying(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	appErr := &errors_app.AppError{
+		Code:    errors_app.ErrCodePlayerNotPlaying,
+		Message: "No hay canción reproduciéndose",
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", "Intento de skip pero no había canción reproduciéndose.", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("SkipSong", mock.Anything).Return(appErr)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageNothingToSkip).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.SkipSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_ListPlaylist_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	songs := []*entity.PlayedSong{
+		{DiscordSong: &entity.DiscordEntity{TitleTrack: "Canción 1"}},
+		{DiscordSong: &entity.DiscordEntity{TitleTrack: "Canción 2"}},
+	}
+
+	expectedEmbed := &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{Title: "🎵 Lista de reproducción:", Description: "1. Canción 1\n2. Canción 2\n"},
+			},
+		},
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", "Mostrando lista de reproducción", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("GetPlaylist", mock.Anything).Return(songs, nil)
+	mockDiscordMessenger.On("Respond", mock.Anything, mock.MatchedBy(func(resp *discordgo.InteractionResponse) bool {
+		return resp.Type == expectedEmbed.Type &&
+			len(resp.Data.Embeds) == 1 &&
+			resp.Data.Embeds[0].Title == expectedEmbed.Data.Embeds[0].Title
+	})).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.ListPlaylist(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+}
+
+func TestCommandHandler_ListPlaylist_Empty(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("GetPlaylist", mock.Anything).Return([]*entity.PlayedSong{}, nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, InfoMessagePlaylistEmpty).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.ListPlaylist(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+}
+
+func TestCommandHandler_RemoveSong_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	song := &entity.PlayedSong{DiscordSong: &entity.DiscordEntity{TitleTrack: "Canción Removida"}}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", "Canción eliminada exitosamente", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("RemoveSong", mock.Anything, 2).Return(song, nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, fmt.Sprintf(SuccessMessageSongRemovedFmt, song.DiscordSong.TitleTrack)).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	opt := &discordgo.ApplicationCommandInteractionDataOption{
+		Options: []*discordgo.ApplicationCommandInteractionDataOption{
+			{
+				Type:  discordgo.ApplicationCommandOptionInteger,
+				Name:  "posición",
+				Value: float64(2),
+			},
+		},
+	}
+
+	// Act
+	handler.RemoveSong(interaction, opt)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_GetPlayingSong_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	song := &entity.PlayedSong{DiscordSong: &entity.DiscordEntity{TitleTrack: "Canción Actual"}}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", "Mostrando canción actual", mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("GetPlayedSong", mock.Anything).Return(song, nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, fmt.Sprintf(InfoMessageNowPlayingFmt, song.DiscordSong.TitleTrack)).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.GetPlayingSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_GetPlayingSong_NoSongPlaying(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("GetPlayedSong", mock.Anything).Return(nil, nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageNoCurrentSong).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.GetPlayingSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_PlaySong_Error_NotInVoiceChannel(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+
+	session := &discordgo.Session{State: discordgo.NewState()}
+	session.State.User = &discordgo.User{ID: "bot123"}
+
+	// Guild sin estado de voz para el usuario
+	guild := &discordgo.Guild{
+		ID:          "guild123",
+		VoiceStates: []*discordgo.VoiceState{},
+	}
+	err := session.State.GuildAdd(guild)
+	if err != nil {
+		t.Fatalf("Error al añadir el estado del servidor: %v", err)
+	}
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	opt := &discordgo.ApplicationCommandInteractionDataOption{
+		Options: []*discordgo.ApplicationCommandInteractionDataOption{
+			{
+				Type:  discordgo.ApplicationCommandOptionString,
+				Name:  "song",
+				Value: "test song",
+			},
+		},
+	}
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, ErrorMessageNotInVoiceChannel).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	// Act
+	handler.PlaySong(session, interaction, opt)
+
+	// Assert
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_PauseSong_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("Pause", mock.Anything).Return(nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, SuccessMessagePaused).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.PauseSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestCommandHandler_ResumeSong_Success(t *testing.T) {
+	// Arrange
+	mockStorage := new(MockInteractionStorage)
+	mockLogger := new(logging.MockLogger)
+	mockGuildManager := new(MockGuildManager)
+	mockDiscordMessenger := new(MockDiscordMessenger)
+	mockQueueManager := new(MockPlayRequestService)
+	mockGuildPlayer := new(MockGuildPlayer)
+
+	mockLogger.On("With", mock.Anything).Return(mockLogger)
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockGuildManager.On("GetGuildPlayer", "guild123").Return(mockGuildPlayer, nil)
+	mockGuildPlayer.On("Resume", mock.Anything).Return(nil)
+	mockDiscordMessenger.On("RespondWithMessage", mock.Anything, SuccessMessageResumed).Return(nil)
+
+	handler := NewCommandHandler(mockStorage, mockLogger, mockGuildManager, mockDiscordMessenger, mockQueueManager)
+
+	interaction := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			GuildID:   "guild123",
+			ChannelID: "channel123",
+			Member: &discordgo.Member{
+				User: &discordgo.User{
+					ID:       "user123",
+					Username: "testUser",
+				},
+			},
+		},
+	}
+
+	// Act
+	handler.ResumeSong(interaction)
+
+	// Assert
+	mockGuildManager.AssertExpectations(t)
+	mockGuildPlayer.AssertExpectations(t)
+	mockDiscordMessenger.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/command/mocks.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/command/mocks.go
@@ -1,0 +1,155 @@
+package command
+
+import (
+	"context"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/entity"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/model"
+	"github.com/Tomas-vilte/ButakeroMusicBotGo/microservices/butakero_bot/internal/domain/ports"
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockInteractionStorage struct {
+	mock.Mock
+}
+
+func (m *MockInteractionStorage) SaveSongList(channelID string, list []*entity.DiscordEntity) {
+	args := m.Called(channelID, list)
+	if args.Get(0) != nil {
+		panic(args.Get(0))
+	}
+}
+
+func (m *MockInteractionStorage) GetSongList(channelID string) []*entity.DiscordEntity {
+	args := m.Called(channelID)
+	if args.Get(0) != nil {
+		panic(args.Get(0))
+	}
+	return args.Get(0).([]*entity.DiscordEntity)
+}
+
+func (m *MockInteractionStorage) DeleteSongList(channelID string) {
+	m.Called(channelID)
+}
+
+type MockDiscordMessenger struct {
+	mock.Mock
+}
+
+func (m *MockDiscordMessenger) RespondWithMessage(interaction *discordgo.Interaction, message string) error {
+	args := m.Called(interaction, message)
+	return args.Error(0)
+}
+
+func (m *MockDiscordMessenger) SendPlayStatus(channelID string, playMsg *entity.PlayedSong) (messageID string, err error) {
+	args := m.Called(channelID, playMsg)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockDiscordMessenger) UpdatePlayStatus(channelID, messageID string, playMsg *entity.PlayedSong) error {
+	args := m.Called(channelID, messageID, playMsg)
+	return args.Error(0)
+}
+
+func (m *MockDiscordMessenger) Respond(interaction *discordgo.Interaction, response *discordgo.InteractionResponse) error {
+	args := m.Called(interaction, response)
+	return args.Error(0)
+}
+
+func (m *MockDiscordMessenger) EditMessageByID(channelID, messageID string, content string) error {
+	args := m.Called(channelID, messageID, content)
+	return args.Error(0)
+}
+
+func (m *MockDiscordMessenger) GetOriginalResponseID(interaction *discordgo.Interaction) (string, error) {
+	args := m.Called(interaction)
+	if args.Get(0) == nil {
+		return "", args.Error(1)
+	}
+	return args.String(0), args.Error(1)
+}
+
+type MockGuildManager struct {
+	mock.Mock
+}
+
+func (m *MockGuildManager) CreateGuildPlayer(guildID string) (ports.GuildPlayer, error) {
+	args := m.Called(guildID)
+	return args.Get(0).(ports.GuildPlayer), args.Error(1)
+}
+
+func (m *MockGuildManager) RemoveGuildPlayer(guildID string) error {
+	args := m.Called(guildID)
+	return args.Error(0)
+}
+
+func (m *MockGuildManager) GetGuildPlayer(guildID string) (ports.GuildPlayer, error) {
+	args := m.Called(guildID)
+	return args.Get(0).(ports.GuildPlayer), args.Error(1)
+}
+
+type MockGuildPlayer struct {
+	mock.Mock
+}
+
+func (m *MockGuildPlayer) Stop(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) Pause(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) Resume(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) SkipSong(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) AddSong(ctx context.Context, textChannelID, voiceChannelID *string, playedSong *entity.PlayedSong) error {
+	args := m.Called(ctx, textChannelID, voiceChannelID, playedSong)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) RemoveSong(ctx context.Context, position int) (*entity.PlayedSong, error) {
+	args := m.Called(ctx, position)
+	return args.Get(0).(*entity.PlayedSong), args.Error(1)
+}
+
+func (m *MockGuildPlayer) GetPlaylist(ctx context.Context) ([]*entity.PlayedSong, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*entity.PlayedSong), args.Error(1)
+}
+
+func (m *MockGuildPlayer) GetPlayedSong(ctx context.Context) (*entity.PlayedSong, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entity.PlayedSong), args.Error(1)
+}
+
+func (m *MockGuildPlayer) MoveToVoiceChannel(ctx context.Context, newChannelID string) error {
+	args := m.Called(ctx, newChannelID)
+	return args.Error(0)
+}
+
+func (m *MockGuildPlayer) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+type MockPlayRequestService struct {
+	mock.Mock
+}
+
+func (m *MockPlayRequestService) Enqueue(guildID string, data model.PlayRequestData) <-chan model.PlayResult {
+	args := m.Called(guildID, data)
+	return args.Get(0).(<-chan model.PlayResult)
+}

--- a/microservices/butakero_bot/internal/infrastructure/discord/guild_manager.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/guild_manager.go
@@ -57,7 +57,6 @@ func (f *GuildPlayerFactory) CreatePlayer(guildID string) (ports.GuildPlayer, er
 			PlaybackHandler: playbackHandler,
 			SongStorage:     songStorage,
 			StateStorage:    stateStorage,
-			Messenger:       f.messenger,
 			Logger:          f.logger,
 		},
 	)

--- a/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
+++ b/microservices/butakero_bot/internal/infrastructure/discord/player/player.go
@@ -25,7 +25,6 @@ type Config struct {
 	PlaybackHandler PlaybackHandler
 	SongStorage     ports.PlaylistStorage
 	StateStorage    ports.PlayerStateStorage
-	Messenger       interfaces.DiscordMessenger
 	StorageAudio    ports.StorageAudio
 	Logger          logging.Logger
 }


### PR DESCRIPTION
- **Added mock implementations for interaction storage, Discord messenger, and guild management:** Provides mock objects for unit testing the command handlers.
  - Purpose: Enables isolated testing of command logic without relying on external dependencies.
  - Technical impact: Introduces `MockInteractionStorage`, `MockDiscordMessenger`, `MockGuildManager`, `MockGuildPlayer` and `MockPlayRequestService` to facilitate mocking.
- **Removed Messenger dependency from audio player creation:** The audio player no longer requires a Messenger instance upon creation.
  - Purpose: Decouples the audio player from direct interaction with Discord, improving modularity and testability.
  - Technical Impact: Reduces dependencies of the `GuildPlayer` struct
- **Added command handler tests:** Unit tests were created to improve code quality, coverage, and confidence.