### PR TITLE
refactor: Simplify directory navigation in build_and_push script

### DIFF
--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -10,17 +10,17 @@ echo "Introduce tu contraseña de Docker Hub:"
 read -s DOCKER_HUB_PASSWORD
 
 echo "Construyendo la imagen para audio_processor..."
-cd audio_processor
+cd audio_processor/
 docker build -t ${DOCKER_HUB_USERNAME}/audio_processor:${VERSION_AUDIO_SERVICE} --build-arg ENV=local -f Dockerfile .
-cd ../..
+cd ..
 
 echo "Construyendo la imagen para bot..."
-cd butakero_bot
+cd butakero_bot/
 docker build -t ${DOCKER_HUB_USERNAME}/butakero_bot:${VERSION_BOT} --build-arg ENV=bot_local -f Dockerfile .
 
 echo "Construyendo la imagen del bot para debug..."
 docker build -t ${DOCKER_HUB_USERNAME}/butakero_bot:${VERSION_BOT}-debug --build-arg ENV=bot_local -f Dockerfile.debug .
-cd ../..
+cd ..
 
 echo "Verificando las imágenes construidas..."
 docker images | grep ${DOCKER_HUB_USERNAME}

--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -10,12 +10,12 @@ echo "Introduce tu contraseña de Docker Hub:"
 read -s DOCKER_HUB_PASSWORD
 
 echo "Construyendo la imagen para audio_processor..."
-cd microservices/audio_processor
+cd audio_processor
 docker build -t ${DOCKER_HUB_USERNAME}/audio_processor:${VERSION_AUDIO_SERVICE} --build-arg ENV=local -f Dockerfile .
 cd ../..
 
 echo "Construyendo la imagen para bot..."
-cd microservices/butakero_bot
+cd butakero_bot
 docker build -t ${DOCKER_HUB_USERNAME}/butakero_bot:${VERSION_BOT} --build-arg ENV=bot_local -f Dockerfile .
 
 echo "Construyendo la imagen del bot para debug..."


### PR DESCRIPTION
- **Simplified `cd` commands for `audio_processor`:** Replaced `cd microservices/audio_processor` with `cd audio_processor/` and `cd ../..` with `cd ..` in the `build_and_push.sh` script.  Purpose is to simplify navigation to the `audio_processor` directory for building. Technical impact is reduced complexity and improved readability of the script.
- **Simplified `cd` commands for `butakero_bot`:**  Replaced `cd microservices/butakero_bot` with `cd butakero_bot/` and `cd ../..` with `cd ..` in the `build_and_push.sh` script.  Purpose is to simplify navigation to the `butakero_bot` directory for building. Technical impact is reduced complexity and improved readability of the script.
- **Unified directory change pattern:** Both microservices directory changes follow the same simplified pattern. Purpose is consistency across the script.